### PR TITLE
Fix Qidi Auto-Z Offset after changes in upstream Klipper

### DIFF
--- a/klipper_module/qidi_auto_z_offset/auto_z_offset.py
+++ b/klipper_module/qidi_auto_z_offset/auto_z_offset.py
@@ -15,6 +15,7 @@ class AutoZOffsetCommandHelper(probe.ProbeCommandHelper):
     def __init__(self, config, mcu_probe, query_endstop=None):
         self.printer = config.get_printer()
         self.name = config.get_name()
+        gcode = self.printer.lookup_object('gcode')
         self.mcu_probe = mcu_probe
         self.query_endstop = query_endstop
         self.z_offset = config.getfloat("z_offset", -0.1)
@@ -23,6 +24,7 @@ class AutoZOffsetCommandHelper(probe.ProbeCommandHelper):
         self.calibrated_z_offset = config.getfloat("calibrated_z_offset", 0.0)
         self.last_state = False
         self.last_z_result = 0.0
+        self.last_probe_position = gcode.Coord((0., 0., 0.))
 
         # Register commands
         self.gcode = self.printer.lookup_object("gcode")


### PR DESCRIPTION
This fixes allows Klipper to start up if it has been updated to any version after commit `32a5f2b`.

The problem is caused by a change in the `ProbeCommandHelper` class which must be incorporated into `AutoZOffsetCommandHelper`.

This change _only_ makes Klipper start up. I have not done any testing of auto-z offset (I don't use it). Looking at the upstream change, other changes to replace references to `last_z_result` with `last_probe_position` should probably be made in `auto_z_offset.py`.