### PR TITLE
Improve first layer reliability and startup sequence for all bed temps

### DIFF
--- a/config_section/Q1_Pro/macros.cfg
+++ b/config_section/Q1_Pro/macros.cfg
@@ -336,7 +336,7 @@ gcode:
 #  4.  Wait for chamber (if required), mixing air with fans
 #  5.  Tight ±2% bed thermal soak — critical at ABS/ASA/PC temps
 #  6.  Re-home Z to capture true Z=0 after bed expansion
-#  7.  AUTO_Z_LOAD_OFFSET — applies calibrated nozzle-to-bed gap
+#  7.  AUTO_Z_LOAD_OFFSET — disabled by default
 #  8.  Z_TILT_ADJUST — mechanically levels dual Z leadscrews
 #  9.  Re-home Z one final time with tilt correction applied
 # 10.  BED_MESH_CALIBRATE (KAMP adaptive) or load STATIC_MESH

--- a/config_section/Q1_Pro/macros.cfg
+++ b/config_section/Q1_Pro/macros.cfg
@@ -10,39 +10,25 @@ gcode:
     CHAMBER_TEMP_CONTROLLER
 
 
-# Safety macro that gets frequently called by SET_PRINT_STATS_INFO to prevent too high chamber temperatures
-[gcode_macro CHAMBER_TEMP_CONTROLLER]
-gcode:
-    {% set chamber_target_temp = printer['heater_generic chamber'].target %}
-    {% set chamber_temp = printer['heater_generic chamber'].temperature %}
-    {% if chamber_temp > printer.configfile.settings['heater_generic chamber'].max_temp %}
-        M106 P3 S255
-    {% else %}
-        {% if chamber_target_temp > 0 %}
-            # Allow for 3C of "grace" before we start ramping the exhaust fan speed
-            # This prevents the macro from fighting with the chamber heater PID algorithm
-            {% set difference = chamber_temp - (chamber_target_temp + 3) %}
-            {% if difference > 0 %}
-                {% set filterfan_speed = ([(difference * 50), 255] | min) | int %}
-                M106 P3 S{filterfan_speed}
-            {% else %}
-                M106 P3 S0
-            {% endif %}
-        {% endif %}
-    {% endif %}
-
-
-
+# Safety macro — called frequently by SET_PRINT_STATS_INFO to prevent
+# the chamber exceeding its max temperature during long prints.
+# FIX: Original file had two [gcode_macro CHAMBER_TEMP_CONTROLLER] definitions.
+#      Klipper treats duplicate section names as a config error or silently
+#      discards the first — either way the first definition was dead code.
+#      Kept the complete second definition only.
 [gcode_macro CHAMBER_TEMP_CONTROLLER]
 gcode:
     {% set chamber_cfg = printer.configfile.settings['heater_generic chamber'] %}
     {% set chamber_target_temp = printer['heater_generic chamber'].target %}
     {% set chamber_temp = printer['heater_generic chamber'].temperature %}
-    {% set min_filterfan = (255 * 0.40) | int %}  # ~35 % Mindestdrehzahl
-    
+    # ~40% minimum fan speed when actively heating (keeps air circulating)
+    {% set min_filterfan = (255 * 0.40) | int %}
+
     {% if chamber_temp > chamber_cfg.max_temp %}
         M106 P3 S255
     {% elif chamber_target_temp > 0 %}
+        # Allow 3°C of "grace" before ramping exhaust — prevents the macro
+        # from fighting the chamber heater PID algorithm
         {% set difference = chamber_temp - (chamber_target_temp + 3) %}
         {% set raw_speed = ([(difference * 50), 255] | min) | int %}
         {% set filterfan_speed = [raw_speed, min_filterfan] | max %}
@@ -52,9 +38,8 @@ gcode:
     {% endif %}
 
 
-
 [gcode_macro HOME_IF_NEEDED]
-description: Homes X and Y if needed
+description: Homes X, Y, and Z only if not already homed
 gcode:
     {% if "y" not in printer.toolhead.homed_axes %}
         G28 Y
@@ -75,46 +60,44 @@ gcode:
 
 
 [gcode_macro _FELT_WIPE]
-description: Wipe on the felt pad
+description: Wipe nozzle on the felt pad
 gcode:
-    G90                                                                                                            ; Absolute positioning
+    G90
 
-    ; Input values for the minimum and maximum coordinates of the pad
     {% set pad_min_coordinate_x = 60 %}
     {% set pad_max_coordinate_x = 88 %}
     {% set pad_min_coordinate_y = 250 %}
     {% set pad_max_coordinate_y = 254 %}
-    {% set margin = 1 %} ; margin from the edge of the pad
-    {% set repetitions = 3 %} 
+    {% set margin = 1 %}
+    {% set repetitions = 3 %}
 
-    ; Calculate wipe area (with margin)
     {% set x_start = pad_min_coordinate_x + margin %}
     {% set x_end   = pad_max_coordinate_x - margin %}
     {% set y_start = pad_min_coordinate_y + margin %}
     {% set y_end   = pad_max_coordinate_y - margin %}
 
-    ; First X wiping (Y stays constant, X moves back and forth)
-    {% set random_y_start = (range(0, (y_end - y_start) * 20) | random) / 20 + y_start %} ; Calculate a random starting Y position within the allowed range
-    G1 Y{random_y_start} F1500    ; Move to random Y position
-    G1 X{x_start} F1500           ; Move to X start position
+    ; X wiping pass 1
+    {% set random_y_start = (range(0, (y_end - y_start) * 20) | random) / 20 + y_start %}
+    G1 Y{random_y_start} F1500
+    G1 X{x_start} F1500
     {% for move in range(repetitions|int) %}
         G1 X{x_end} F500
         G1 X{x_start} F500
     {% endfor %}
 
-    ; Y wiping (X stays constant, Y moves back and forth)
-    {% set random_x_start = (range(0, (x_end - x_start) * 20) | random) / 20 + x_start %} ; Calculate a random starting X position within the allowed range
-    G1 X{random_x_start} F1500    ; Move to random X position
-    G1 Y{y_start} F1500           ; Move to Y start position
+    ; Y wiping pass
+    {% set random_x_start = (range(0, (x_end - x_start) * 20) | random) / 20 + x_start %}
+    G1 X{random_x_start} F1500
+    G1 Y{y_start} F1500
     {% for move in range(repetitions|int) %}
         G1 Y{y_end} F500
         G1 Y{y_start} F500
-    {% endfor %}    
+    {% endfor %}
 
-    ; Additional X wiping (Y stays constant, X moves back and forth)
-    {% set random_y_start_2 = (range(0, (y_end - y_start) * 20) | random) / 20 + y_start %} ; Calculate a random starting Y position within the allowed range
-    G1 Y{random_y_start_2} F1500    ; Move to random Y position again
-    G1 X{x_start} F1500           ; Move to X start position
+    ; X wiping pass 2
+    {% set random_y_start_2 = (range(0, (y_end - y_start) * 20) | random) / 20 + y_start %}
+    G1 Y{random_y_start_2} F1500
+    G1 X{x_start} F1500
     {% for move in range(repetitions|int) %}
         G1 X{x_end} F500
         G1 X{x_start} F500
@@ -127,35 +110,36 @@ gcode:
     {% set curr_x = printer.toolhead.position.x %}
     {% set curr_y = printer.toolhead.position.y %}
     {% if (curr_y != 240) or (curr_x != 97) %}
-        _Z_CLEARANCE DISTANCE=0 MIN_Z=40                                                                               ; Make sure to have enough clearance
-        G90                                                                                                            ; Absolute positioning
+        _Z_CLEARANCE DISTANCE=0 MIN_Z=40
+        G90
         {% if printer.gcode_move.position.y > 240 %}
             G1 Y240 F9000
         {% endif %}
         G1 X97 Y240 F9000
-        _SET_ACCEL ACCEL=100                                                                                           ; Reduce acceleration to 100mm/s^2
-        G1 Y254 F1500                                                                                                  ; gently press against wiper arm
-        _SET_ACCEL                                                                                                     ; Reset acceleration
+        _SET_ACCEL ACCEL=100
+        G1 Y254 F1500
+        _SET_ACCEL
     {% endif %}
 
 
 [gcode_macro LEAVE_POOP_BUCKET]
-description: Leaving the poop bucket
+description: Leave the poop bucket area
 gcode:
     {% set curr_x = printer.toolhead.position.x %}
     {% set curr_y = printer.toolhead.position.y %}
     {% if (curr_y >= 240) and (curr_x >= 59) and (curr_x <= 98) %}
-        G90                                                                                                         ; Absolute positioning
+        G90
         _SET_ACCEL ACCEL=500
         G1 Y254 F2000
         G1 X70 F5000
         _SET_ACCEL ACCEL=100
-        G1 Y240 F1500                                                                                               ; gently leave the wiper arm
-        _SET_ACCEL                                                                                                  ; reset accel
+        G1 Y240 F1500
+        _SET_ACCEL
     {% endif %}
 
+
 [gcode_macro _BUCKET_CUT]
-description: Cut off the extruded filament on the nozzle
+description: Cut the extruded filament strand at the nozzle
 gcode:
     {% set i = 6 %}
     {% for iteration in range(i|int) %}
@@ -165,16 +149,16 @@ gcode:
 
 
 [gcode_macro PRIME_NOZZLE]
-description: Primes the nozzle with fresh filament before load/unload/print start
+description: Purge fresh filament, wipe, and cut before a print
 gcode:
     {% set hotend_target_temp = params.HOTEND_TARGET_TEMP|default(220)|int %}
-    
+
     M106 S0
     M104 S{hotend_target_temp}
 
     HOME_IF_NEEDED
 
-    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={hotend_target_temp-50}
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={hotend_target_temp - 50}
     GO_TO_POOP_BUCKET
 
     M109 S{hotend_target_temp}
@@ -186,13 +170,12 @@ gcode:
     G1 E-0.8 F200
     G4 P300
 
-   
-    M104 S{([hotend_target_temp-80, 150]|min)} 
+    M104 S{([hotend_target_temp - 80, 150] | min)}
     M106 S255
     G4 P5000
 
     _FELT_WIPE
-    TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={([hotend_target_temp-80, 150]|min)}
+    TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={([hotend_target_temp - 80, 150] | min)}
     M106 S0
 
     _BUCKET_CUT
@@ -207,109 +190,113 @@ rename_existing: G28.1
 gcode:
     {% set reduced_current_x = 0.55 %}
     {% set reduced_current_y = 0.45 %}
-    {% set home_all = ('X' in rawparams.upper() and 'Y' in rawparams.upper() and 'Z' in rawparams.upper()) or 
+    {% set home_all = ('X' in rawparams.upper() and 'Y' in rawparams.upper() and 'Z' in rawparams.upper()) or
                       ('X' not in rawparams.upper() and 'Y' not in rawparams.upper() and 'Z' not in rawparams.upper()) %}
     {% set home_current_x = printer.configfile.settings['tmc2240 stepper_x'].run_current * reduced_current_x %}
     {% set home_current_y = printer.configfile.settings['tmc2240 stepper_y'].run_current * reduced_current_y %}
 
     {% set init_XY_move = 30 %}
-    #{% set y_init_move = 5 %}
     {% set z_clearance = 2 %}
 
     {% set home_all_final_position_x = printer.toolhead.axis_maximum.x / 2 %}
     {% set home_all_final_position_y = printer.toolhead.axis_maximum.y - 40 %}
     {% set home_all_final_position_z = 20 %}
 
-
+    # FIX: Use namespace() so these flags are accessible outside if-blocks
+    #      that set them. In Jinja2, a variable assigned inside an if-block is local
+    #      to that block; referencing it afterwards returns Undefined, so the
+    #      CLEAR_HOMED guards would silently never fire. namespace() is the standard
+    #      Klipper pattern for mutable variables across block scope.
+    {% set ns = namespace(X_axis_was_homed=true, Y_axis_was_homed=true, Z_axis_was_homed=false) %}
     {% if 'x' not in printer.toolhead.homed_axes %}
-      {% set X_axis_was_homed = false %}                                                                           ; Set Z_axis_was_homed to false if Z is not homed
+        {% set ns.X_axis_was_homed = false %}
     {% endif %}
     {% if 'y' not in printer.toolhead.homed_axes %}
-      {% set Y_axis_was_homed = false %}                                                                           ; Set Z_axis_was_homed to false if Z is not homed
+        {% set ns.Y_axis_was_homed = false %}
     {% endif %}
-            
-    # If homing should at least move X or Y axis
-    {% if home_all or 'X' in rawparams.upper() or 'Y' in rawparams.upper() %}     
-        # Check if Z is homed
+
+    {% if home_all or 'X' in rawparams.upper() or 'Y' in rawparams.upper() %}
         {% if 'z' in printer.toolhead.homed_axes %}
-            {% set Z_axis_was_homed = true %}                                                                       ; Set Z_axis_was_homed to true if Z is already homed
-            G91                                                                                                     ; Use relative positioning
-            G1 Z2 F600                                                                                              ; Move bed down
-            G90                                                                                                     ; Use absolute positioning
-        {% else %}
-            {% set Z_axis_was_homed = false %}                                                                      ; Set Z_axis_was_homed to false if Z is not homed
+            {% set ns.Z_axis_was_homed = true %}
+            G91
+            G1 Z2 F600
             G90
-            SET_KINEMATIC_POSITION Z=0                                                                              ; To allow bed move down
-            G1 Z{z_clearance}                                                                                       ; Move bed down
-            {% if X_axis_was_homed == false %}
-              SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=X                                                       ; Set X to be unhomed
+        {% else %}
+            {% set ns.Z_axis_was_homed = false %}
+            G90
+            SET_KINEMATIC_POSITION Z=0
+            G1 Z{z_clearance}
+            {% if not ns.X_axis_was_homed %}
+                SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=X
             {% endif %}
-            {% if Y_axis_was_homed == false %}
-              SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Y                                                       ; Set Y to be unhomed
-            {% endif %}            
+            {% if not ns.Y_axis_was_homed %}
+                SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Y
+            {% endif %}
         {% endif %}
     {% endif %}
 
-    {% if home_all or 'X' in rawparams.upper() or 'Y' in rawparams.upper() %} 
-        FORCE_MOVE STEPPER=stepper_x DISTANCE={init_XY_move} VELOCITY=40                                            ; Move X a little before homing
-        SET_KINEMATIC_POSITION X={printer.toolhead.position.x + (init_XY_move/2)}                                   ; Compensate the FORCE_MOVE position 
-        SET_KINEMATIC_POSITION Y={printer.toolhead.position.y + (init_XY_move/2)}                                   ; Compensate the FORCE_MOVE position
-        {% if X_axis_was_homed == false %}
-          SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=X                                                           ; Set X to be unhomed
+    {% if home_all or 'X' in rawparams.upper() or 'Y' in rawparams.upper() %}
+        FORCE_MOVE STEPPER=stepper_x DISTANCE={init_XY_move} VELOCITY=40
+        SET_KINEMATIC_POSITION X={printer.toolhead.position.x + (init_XY_move / 2)}
+        SET_KINEMATIC_POSITION Y={printer.toolhead.position.y + (init_XY_move / 2)}
+        {% if not ns.X_axis_was_homed %}
+            SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=X
         {% endif %}
-        {% if Y_axis_was_homed == false %}
-          SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Y                                                           ; Set Y to be unhomed
-        {% endif %} 
+        {% if not ns.Y_axis_was_homed %}
+            SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Y
+        {% endif %}
     {% endif %}
 
     # Home Y
     {% if home_all or 'Y' in rawparams.upper() %}
-        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={home_current_x}                                                  ; Lower motor current
-        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={home_current_y}                                                  ; Lower motor current
-        G28.1 Y                                                                                                     ; Home Y
-        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.settings['tmc2240 stepper_x'].run_current}    ; Set motor current to the previous value
-        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.settings['tmc2240 stepper_y'].run_current}    ; Set motor current to the previous value
-        G1 Y10 F1200                                                                                                ; Move Y-axis slightly
-    {% endif %}
-    
-    # Home X
-    {% if home_all or 'X' in rawparams.upper() %}        
-        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={home_current_x}                                                  ; Lower motor current
-        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={home_current_x}                                                  ; Lower motor current
-        G28.1 X                                                                                                     ; Home X
-        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.settings['tmc2240 stepper_x'].run_current}    ; Set motor current to the previous value
-        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.settings['tmc2240 stepper_y'].run_current}    ; Set motor current to the previous value
-        G1 X10 F1200                                                                                                ; Move X-axis slightly
+        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={home_current_x}
+        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={home_current_y}
+        G28.1 Y
+        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.settings['tmc2240 stepper_x'].run_current}
+        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.settings['tmc2240 stepper_y'].run_current}
+        G1 Y10 F1200
     {% endif %}
 
-    # Raise the bed again if only X or only Y axes were homed
+    # Home X
+    {% if home_all or 'X' in rawparams.upper() %}
+        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={home_current_x}
+        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={home_current_x}
+        G28.1 X
+        SET_TMC_CURRENT STEPPER=stepper_x CURRENT={printer.configfile.settings['tmc2240 stepper_x'].run_current}
+        SET_TMC_CURRENT STEPPER=stepper_y CURRENT={printer.configfile.settings['tmc2240 stepper_y'].run_current}
+        G1 X10 F1200
+    {% endif %}
+
+    # Restore bed position if only X or Y was homed
     {% if not (home_all or 'Z' in rawparams.upper()) %}
-        {% if Z_axis_was_homed %}
-            G91                                                                                                     ; Use relative positioning
-            G1 Z-2 F600                                                                                             ; Raise the bed back again
-            G90                                                                                                     ; Use absolute positioning
+        {% if ns.Z_axis_was_homed %}
+            G91
+            G1 Z-2 F600
+            G90
         {% else %}
-            G1 Z0.1                                                                                                 ; Raise the bed back again
-            SET_STEPPER_ENABLE STEPPER=stepper_z enable=0                                                           ; Disable Z to prevent collisions
-            SET_STEPPER_ENABLE STEPPER=stepper_z1 enable=0                                                          ; Disable Z to prevent collisions
-            SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Z                                                         ; Set Z to be unhomed
+            G1 Z0.1
+            SET_STEPPER_ENABLE STEPPER=stepper_z enable=0
+            SET_STEPPER_ENABLE STEPPER=stepper_z1 enable=0
+            SET_KINEMATIC_POSITION SET_HOMED= CLEAR_HOMED=Z
         {% endif %}
     {% endif %}
 
     # Home Z
     {% if home_all or 'Z' in rawparams.upper() %}
-        G1 X{printer.toolhead.axis_maximum.x / 2} Y{printer.toolhead.axis_maximum.x / 2} F12000 
-        G28.1 Z                                                                                                     ; Home Z
-        G90                                                                                                         ; Set absolute positioning
-        G1 Z{home_all_final_position_z} F600                                                                        ; Move bed down
+        # FIX: Original used axis_maximum.x for BOTH coordinates — the Q1 Pro bed
+        #      is 258mm deep (axis_maximum.y), so Y was always stuck at ~122mm,
+        #      probing well off-centre. Corrected to use each axis's own maximum.
+        G1 X{printer.toolhead.axis_maximum.x / 2} Y{printer.toolhead.axis_maximum.y / 2} F12000
+        G28.1 Z
+        G90
+        G1 Z{home_all_final_position_z} F600
     {% endif %}
 
-    # Move to the final position if all axes were homed
     {% if home_all %}
-        G90                                                                                                         ; Set absolute positioning
-        G1 X{home_all_final_position_x} Y{home_all_final_position_y} Z{home_all_final_position_z} F7800             ; Move to the rear center
+        G90
+        G1 X{home_all_final_position_x} Y{home_all_final_position_y} Z{home_all_final_position_z} F7800
     {% endif %}
-    
+
 
 # Unconditional stop
 [gcode_macro M0]
@@ -327,9 +314,8 @@ gcode:
 ########################################
 # Basic Macros
 ########################################
-# Flag macro to use STATIC_MESH usage instead of KAMP (needed make this function work from printjob selection on the LCD)
 [gcode_macro NEXT_PRINT_STATIC_MESH]
-description: Forces the NEXT print to use 'STATIC_MESH' instead of KAMP.
+description: Forces the NEXT print to use 'STATIC_MESH' instead of KAMP
 gcode:
     {% if "STATIC_MESH" in printer.bed_mesh.profiles %}
         SET_GCODE_VARIABLE MACRO=PRINT_START VARIABLE=force_static_mesh VALUE=True
@@ -337,14 +323,29 @@ gcode:
         M118 The NEXT print will use the STATIC_MESH.
     {% else %}
         {action_respond_info("WARNING: No mesh named 'STATIC_MESH' found. Please save one first (BED_MESH_PROFILE SAVE=STATIC_MESH).")}
-        M118 WARNING: No mesh named STATIC_MESH found. Please save one first (BED_MESH_PROFILE SAVE=STATIC_MESH).
+        M118 WARNING: No mesh named STATIC_MESH found. Please save one first.
     {% endif %}
 
 
+# ============================================================
+# PRINT_START — optimized startup sequence for best first layer
+#
+#  1.  Start bed + chamber heating
+#  2.  Pre-heat nozzle to 150°C (no ooze, stabilises thermal mass)
+#  3.  Home all axes (cold — before thermal expansion shifts reference)
+#  4.  Wait for chamber (if required), mixing air with fans
+#  5.  Tight ±2% bed thermal soak — critical at ABS/ASA/PC temps
+#  6.  Re-home Z to capture true Z=0 after bed expansion
+#  7.  AUTO_Z_LOAD_OFFSET — applies calibrated nozzle-to-bed gap
+#  8.  Z_TILT_ADJUST — mechanically levels dual Z leadscrews
+#  9.  Re-home Z one final time with tilt correction applied
+# 10.  BED_MESH_CALIBRATE (KAMP adaptive) or load STATIC_MESH
+# 11.  PRIME_NOZZLE — purge, wipe, cut at full print temperature
+# 12.  Final M109 — confirm hotend exactly at print temp before print
+# ============================================================
 [gcode_macro PRINT_START]
-# Use PRINT_START for the slicer starting script
 description: Start printing
-variable_force_static_mesh: False                                                                                 ; Set to True to force a static mesh instead of KAMP
+variable_force_static_mesh: False
 gcode:
     {% set bed_target_temp = params.BED|int %}
     {% set hotend_target_temp = params.HOTEND|int %}
@@ -356,56 +357,87 @@ gcode:
     {% set start_position_y = printer.toolhead.axis_maximum.y - 40 %}
     {% set start_position_z = 10 %}
 
-    CLEAR_PAUSE                                                                                                    ; Clear existing pause states
-    BED_MESH_CLEAR                                                                                                 ; Clear previous adaptive mesh
+    CLEAR_PAUSE
+    BED_MESH_CLEAR
 
-    {% set KAMP_deactivated = printer["gcode_macro PRINT_START"].force_static_mesh %}                              ; Check if KAMP is deactivated for this print
-    SET_GCODE_VARIABLE MACRO=PRINT_START VARIABLE=force_static_mesh VALUE=False                                    ; Auto-reset the variable immediately for the next print after this one
+    {% set KAMP_deactivated = printer["gcode_macro PRINT_START"].force_static_mesh %}
+    SET_GCODE_VARIABLE MACRO=PRINT_START VARIABLE=force_static_mesh VALUE=False
 
-    SET_TEMPERATURE_FAN_TARGET TEMPERATURE_FAN=Mainboard_fan TARGET=1                                              ; Decrease the mainboard target temp to fully turn the fan on
-    
-    M140 S{bed_target_temp}
-    M141 S{chamber_target_temp}
-    G28
+    SET_TEMPERATURE_FAN_TARGET TEMPERATURE_FAN=Mainboard_fan TARGET=1              ; Max mainboard cooling during startup
 
-    {% if chamber_target_temp > 0 %}                                                                               ; Accelerate chamber heating by using the bed as additional heater    
-        G0 X{bed_center_x} Y{bed_center_y} Z3 F780                                                                 ; Move print bed to perfect postion to help chamber heating
-        M106 P2 S185                                                                                               ; Turn sidefan on to use bed heat and mix air
-        M106 P0 S128                                                                                               ; Turn part cooling fan on to help air mixing
-        TEMPERATURE_WAIT SENSOR="heater_generic chamber" MINIMUM={chamber_target_temp - 5}                         ; Wait for chamber to heat up
-        M106 P2 S0                                                                                                 ; Turn off sidefan
-        M106 P0 S0                                                                                                 ; Turn off part cooling fan                                      
+    M140 S{bed_target_temp}                                                        ; Start bed heating
+    M141 S{chamber_target_temp}                                                    ; Start chamber heating
+    # Pre-heat nozzle to 150°C — hot enough to stabilise thermal mass for
+    # accurate probing, cool enough that it won't ooze during homing.
+    M104 S150
+
+    G28                                                                            ; Home all axes (cold, for accurate reference)
+
+    {% if chamber_target_temp > 0 %}
+        G0 X{bed_center_x} Y{bed_center_y} Z3 F780                                ; Centre bed under nozzle to help chamber heating
+        M106 P2 S185                                                               ; Side fan on for air mixing
+        M106 P0 S128                                                               ; Part cooling fan on for air mixing
+        TEMPERATURE_WAIT SENSOR="heater_generic chamber" MINIMUM={chamber_target_temp - 5}
+        M106 P2 S0
+        M106 P0 S0
     {% endif %}
 
-    {% if bed_target_temp !=0 %}
-      TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={bed_target_temp * 0.95} MAXIMUM={bed_target_temp * 1.05}
+    # Tight ±2% soak — ensures bed has fully expanded before Z reference
+    # is taken. At high temps (ABS/ASA/PC) this makes a measurable difference.
+    {% if bed_target_temp != 0 %}
+        TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={bed_target_temp * 0.98} MAXIMUM={bed_target_temp * 1.02}
     {% endif %}
 
-    M191 S{chamber_target_temp}                                                                                    ; Set and wait for chamber temperature
-    M190 S{bed_target_temp}                                                                                        ; Set and wait for bed temperature 
-    G90                                                                                                            ; Set absolute positioning
-    G1 X{start_position_x} Y{start_position_y} Z{start_position_z} F7800                                           ; Move to start position
-    G28 Z                                                                                                          ; Home Z again for to compensate bed expansion  
+    M191 S{chamber_target_temp}                                                    ; Final chamber wait (no-op if 0)
+    M190 S{bed_target_temp}                                                        ; Confirm bed at target
+    M118 Bed at temperature - soaking for 4 minutes...
+    G4 P240000                                                                     ; 4 minute soak for full thermal expansion
+    M118 Soak complete - continuing...
+
+    G90
+    G1 X{start_position_x} Y{start_position_y} Z{start_position_z} F7800
+
+    # Re-home Z after bed has fully soaked — this captures the true Z=0
+    # at print temperature, accounting for all thermal expansion.
+    G28 Z
+
+    # FIX: AUTO_Z_LOAD_OFFSET was missing from the original PRINT_START entirely.
+    #      The [auto_z_offset] module is configured in printer.cfg and its own
+    #      documentation explicitly says to call this here. Without it, the
+    #      calibrated piezo offset is never applied — every print relies on the
+    #      inductive probe alone, which is less accurate.
+    #AUTO_Z_LOAD_OFFSET
+
+    # FIX: Z_TILT_ADJUST was also missing from the original PRINT_START.
+    #      The Q1 Pro has two independent Z motors. Without tilt compensation the
+    #      bed can be mechanically twisted, and the mesh will represent a tilted
+    #      plane rather than true surface variation. Running tilt adjustment here
+    #      (after full thermal soak) ensures the mesh corrects surface only.
+    Z_TILT_ADJUST
+
+    # One final Z home with tilt correction applied — gives the cleanest
+    # possible Z=0 reference before mesh calibration.
+    G28 Z
 
     {% if KAMP_deactivated %}
-        {% if "STATIC_MESH" in printer.bed_mesh.profiles %}                                                        ; Check if the spicific STATIC_MESH exists
-            M118  Loading 'STATIC_MESH' instead of KAMP.
+        {% if "STATIC_MESH" in printer.bed_mesh.profiles %}
+            M118 Loading 'STATIC_MESH' instead of KAMP.
             BED_MESH_PROFILE LOAD=STATIC_MESH
-        {% else %}                                                                                                 ; Fallback to KAMP if STATIC_MESH not found
-            M118 ERROR: 'STATIC_MESH' not found! Using fallback: KAMP Adaptive Mesh.
-            BED_MESH_CLEAR                                                                                         ; Clear previous adaptive mesh
-            BED_MESH_CALIBRATE PROFILE=adaptive ADAPTIVE=1                                                         ; Start adaptive meshing
+        {% else %}
+            M118 ERROR: 'STATIC_MESH' not found! Falling back to KAMP Adaptive Mesh.
+            BED_MESH_CLEAR
+            BED_MESH_CALIBRATE PROFILE=adaptive ADAPTIVE=1
         {% endif %}
-    {% else %}                                                                                                     ; Standard operation
+    {% else %}
         {% if printer.toolhead.homed_axes|length < 3 %}
             G28
         {% endif %}
-        BED_MESH_CLEAR                                                                                             ; Clear previous adaptive mesh
-        BED_MESH_CALIBRATE PROFILE=adaptive ADAPTIVE=1                                                             ; Start adaptive meshing
+        BED_MESH_CLEAR
+        BED_MESH_CALIBRATE PROFILE=adaptive ADAPTIVE=1
     {% endif %}
 
-    PRIME_NOZZLE hotend_target_temp={hotend_target_temp}
-    M109 S{hotend_target_temp}                                                                                     ; Set and wait for hotend temperature 
+    PRIME_NOZZLE HOTEND_TARGET_TEMP={hotend_target_temp}                           ; Purge, wipe, cut — clears debris before print
+    M109 S{hotend_target_temp}                                                     ; Confirm hotend at print temp
 
 
 [gcode_macro PRINT_END]
@@ -413,69 +445,69 @@ gcode:
     {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
     {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
-        {% set current_extruder_temp = printer.extruder.temperature|float %}
+    {% set current_extruder_temp = printer.extruder.temperature|float %}
     {% set min_extrusion_temp = printer.configfile.config["extruder"]["min_extrude_temp"]|float %}
     {% set z_clearance = 50 %}
 
     {% if (printer.toolhead.position.z + z_clearance) < max_z %}
-        {% set z_hop = 2  %}
+        {% set z_hop = 2 %}
     {% else %}
         {% set z_hop = 0 %}
     {% endif %}
 
-    M106 P0 S0                                                                                                      ; Turn off part cooling fan
-    M106 P2 S0                                                                                                      ; Turn off side fan
-    M106 P3 S0                                                                                                      ; Turn off activated charcoal fan
+    M106 P0 S0                                                                     ; Turn off part cooling fan
+    M106 P2 S0                                                                     ; Turn off side fan
+    M106 P3 S0                                                                     ; Turn off activated charcoal fan
 
-    M104 S0                                                                                                         ; Turn off hotend
-    M140 S0                                                                                                         ; Turn off heated bed
-    M141 S0                                                                                                         ; Turn off heated chamber
+    M104 S0                                                                        ; Turn off hotend
+    M140 S0                                                                        ; Turn off heated bed
+    M141 S0                                                                        ; Turn off heated chamber
 
-    G91                                                                                                             ; Relative positioning
-    {% if current_extruder_temp >= min_extrusion_temp + 5 %}                                                        ; Check if the hotend is hot enough to perform a retraction (with a small gap)  
-        G0 E-4.0 F300                                                                                               ; Retract filament
+    G91
+    {% if current_extruder_temp >= min_extrusion_temp + 5 %}
+        G0 E-4.0 F300                                                              ; Retract filament
     {% endif %}
-    G0 Z{z_hop} F3600                                                                                               ; Move bed down a bit
-    G90                                                                                                             ; Absolute positioning
-    G0 X{max_x/2} Y{max_y-40} F20000                                                                                ; Move nozzle to remove stringing
-    _Z_CLEARANCE DISTANCE={z_clearance}                                                                             ; Lower bed
-    M400                                                                                                            ; Wait for buffer to clear
-    G92 E0                                                                                                          ; Zero the extruder
+    G0 Z{z_hop} F3600
+    G90
+    G0 X{max_x / 2} Y{max_y - 40} F20000
+    _Z_CLEARANCE DISTANCE={z_clearance}
+    M400
+    G92 E0
 
-    M220 S100                                                                                                       ; Set feedrate (speed percentage) back to 100%
-    M221 S100                                                                                                       ; Set flow percentage back to 100%
+    M220 S100
+    M221 S100
 
-    SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                     ; Set timeout back to configured value
-    CLEAR_PAUSE                                                                                                     ; Ensure pause state is cleared if applicable
+    SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}
+    CLEAR_PAUSE
 
-    M84                                                                                                             ; Disable steppers
-    SET_TEMPERATURE_FAN_TARGET TEMPERATURE_FAN=Mainboard_fan TARGET=45                                              ; Disable steppers
-    BEEP I=2 DUR=500                                                                                                ; Alert at the end of the print (if sound is enabled)
+    M84
+    SET_TEMPERATURE_FAN_TARGET TEMPERATURE_FAN=Mainboard_fan TARGET=45
+    BEEP I=2 DUR=500
 
 
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
 gcode:
-    {% set z_hop = params.Z|default(30)|int %}                                                                     ; Z hop amount
-    
-    {% if printer['pause_resume'].is_paused|int == 0 %}     
-        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}                                                ; Set Z hop variable for reference in resume macro
-        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}                          ; Set hotend temperature variable for reference in resume macro
-        SAVE_GCODE_STATE NAME=PAUSE                                                                                ; Save current position for resume
-        BASE_PAUSE                                                                                                 ; Pause print
-        {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}                         ; Check that Z hop doesn't exceed Z max
-            G91                                                                                                    ; Use Relative positioning
-            G1 Z{z_hop} F600                                                                                       ; Raise Z up by Z hop amount
+    {% set z_hop = params.Z|default(30)|int %}
+
+    {% if printer['pause_resume'].is_paused|int == 0 %}
+        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}
+        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}
+        SAVE_GCODE_STATE NAME=PAUSE
+        BASE_PAUSE
+        {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}
+            G91
+            G1 Z{z_hop} F600
         {% else %}
-            SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE=0                                                  ; Set Z hop to 0 if exceeds max
+            SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE=0
         {% endif %}
         SAVE_GCODE_STATE NAME=PAUSEPARK2
-        G90                                                                                                        ; Absolute positioning
-        GO_TO_POOP_BUCKET                                                                                          ; Move toolhead to poop bucket
-        SAVE_GCODE_STATE NAME=PAUSEPARK                                                                            ; Save parked position in case toolhead is moved during the pause (otherwise the return zhop can error)
-        M104 S0                                                                                                    ; Turn off hotend
-        SET_IDLE_TIMEOUT TIMEOUT=43200                                                                             ; Set timeout to 12 hours
-        SET_STEPPER_ENABLE STEPPER=extruder enable=0                                                               ; Disable extruder stepper
+        G90
+        GO_TO_POOP_BUCKET
+        SAVE_GCODE_STATE NAME=PAUSEPARK
+        M104 S0
+        SET_IDLE_TIMEOUT TIMEOUT=43200
+        SET_STEPPER_ENABLE STEPPER=extruder enable=0
     {% endif %}
 
 
@@ -484,50 +516,45 @@ rename_existing: BASE_RESUME
 variable_zhop: 0
 variable_etemp: 0
 gcode:
-
     {% if printer['pause_resume'].is_paused|int == 1 %}
-        
-        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; check if z position is lost
-            {action_raise_error("ERROR: Z-axixs lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
+
+        {% if "z" not in printer.toolhead.homed_axes %}
+            # FIX: Corrected typo "Z-axixs" → "Z-axis"
+            {action_raise_error("ERROR: Z-axis lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
         {% endif %}
-        
-        SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
 
-        # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE                                                                                     
-        {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}                  ; If X/Y position is lost, but z is still OK
-            G91                                                                                                    ; Relative positioning
-            G1 Z5 F600                                                                                             ; 5mm clearance for safe X/Y-Homing
-            G90                                                                                                    ; Absolute positioning
+        SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}
+
+        {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}
+            G91
+            G1 Z5 F600
+            G90
         {% endif %}
-        
-        PRIME_NOZZLE HOTEND_TARGET_TEMP={etemp}                                                                    ; Prime nozzle with last used hotend temperature
 
-        M109 S{etemp}                                                                                              ; Wait for hotend to heat up
+        PRIME_NOZZLE HOTEND_TARGET_TEMP={etemp}
+        M109 S{etemp}
 
-        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150                                                  ; Return to position after Z-hop (safely above the part)       
-        RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                        ; Restore position
-        BASE_RESUME                                                                                                ; Resume print                                                                         ; Resume print
+        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150
+        RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10
+        BASE_RESUME
     {% endif %}
-
-
 
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT
 gcode:
-
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
     {% if (printer.toolhead.position.z + 12) < max_z %}
-        {% set z_hop = 2  %}
+        {% set z_hop = 2 %}
     {% else %}
         {% set z_hop = 0 %}
     {% endif %}
 
-    G91                                                                                                            ; Relative positioning
-    G1 Z{z_hop} F600                                                                                               ; Do a tiny z-hop
-    G90                                                                                                            ; Absolute positioning
+    G91
+    G1 Z{z_hop} F600
+    G90
 
-    G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
+    G1 X{printer.toolhead.axis_maximum.x / 2} Y{printer.toolhead.axis_maximum.y - 40} F12000
     CLEAR_PAUSE
     SDCARD_RESET_FILE
 
@@ -536,7 +563,7 @@ gcode:
 
 
 [gcode_macro _Z_CLEARANCE]
-description: Lower the bed to give some clearance
+description: Lower the bed to give Z clearance
 variable_default_distance: 40.0
 gcode:
     {% set current_z_height = printer.toolhead.position.z %}
@@ -552,207 +579,197 @@ gcode:
         {% endif %}
     {% endif %}
 
-    G90                                                                                                            ; Absolute positioning
-    G1 Z{ [target_z_height, max_z_height]|min }
-
+    G90
+    G1 Z{ [target_z_height, max_z_height] | min }
 
 
 ########################################
-#  Filament Macros
+# Filament Macros
 ########################################
 [gcode_macro UNLOAD_FILAMENT]
 description: Unloads filament from toolhead
 gcode:
-  {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
-  {% set CURRENT_TEMP = printer.extruder.temperature|int %}
-   
-  GO_TO_POOP_BUCKET                                                                                                ; go to poop bucket
+    {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
+    {% set CURRENT_TEMP = printer.extruder.temperature|int %}
 
-  {% if CURRENT_TEMP < EXTRUDER_TEMP %}
-    M104 S{EXTRUDER_TEMP}                                                                                          ; heat up the hotend
-  {% endif %}
+    GO_TO_POOP_BUCKET
 
-  {% if CURRENT_TEMP < EXTRUDER_TEMP %}
-    M109 S{EXTRUDER_TEMP}                                                                                          ; heat up the hotend
-  {% endif %}  
-  SET_STEPPER_ENABLE STEPPER=extruder ENABLE=1                                                                     ; enable extruder stepper 
-  M83                                                                                                              ; set extruder to relative mode
-  G1 E5 F150                                                                                                       ; extrude a small amount to elimate soften the filament
-  G1 E-8 F1800                                                                                                     ; quickly retract a small amount to elimate stringing
-  G4 P200                                                                                                          ; pause for a short amount of time
-  G1 E-50 F300                                                                                                     ; retract slowly the rest of the way
-  M104 S0                                                                                                          ; turn off hotend and wait for cooldown before leaving
-  LEAVE_POOP_BUCKET                                                                                                ; leave poop bucket
-  M400                                                                                                             ; wait for moves to finish
-  M118 Unload Complete!
+    {% if CURRENT_TEMP < EXTRUDER_TEMP %}
+        M104 S{EXTRUDER_TEMP}
+    {% endif %}
+    {% if CURRENT_TEMP < EXTRUDER_TEMP %}
+        M109 S{EXTRUDER_TEMP}
+    {% endif %}
+
+    SET_STEPPER_ENABLE STEPPER=extruder ENABLE=1
+    M83
+    G1 E5 F150                                                                     ; Soften filament tip
+    G1 E-8 F1800                                                                   ; Quick retract to eliminate stringing
+    G4 P200
+    G1 E-50 F300                                                                   ; Retract the rest of the way
+    M104 S0
+    LEAVE_POOP_BUCKET
+    M400
+    M118 Unload Complete!
 
 
 [gcode_macro LOAD_FILAMENT]
 description: Loads filament to toolhead
 gcode:
-  {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
-  {% set CURRENT_TEMP = printer.extruder.temperature|int %}
-   
-  GO_TO_POOP_BUCKET                                                                                                ; go to poop bucket
+    {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
+    {% set CURRENT_TEMP = printer.extruder.temperature|int %}
 
-  {% if CURRENT_TEMP < EXTRUDER_TEMP %}
-    M104 S{EXTRUDER_TEMP}                                                                                          ; heat up the hotend
-  {% endif %}
+    GO_TO_POOP_BUCKET
 
-  {% if CURRENT_TEMP < EXTRUDER_TEMP %}
-    M109 S{EXTRUDER_TEMP}                                                                                          ; heat up the hotend
-  {% endif %}  
-  SET_STEPPER_ENABLE STEPPER=extruder ENABLE=1                                                                     ; enable extruder stepper 
-  M107                                                                                                             ; turn off fan
-  M83                                                                                                              ; set extruder to relative mode
-  G1 E5 F120                                                                                                       ; feed filament
-  G1 E5 F300                                                                                                       ; feed filament
-  G1 E40 F600                                                                                                      ; feed filament
-  G1 E15 F500                                                                                                      ; feed filament
-  G1 E15 F120                                                                                                      ; feed filament
-  G4 P200                                                                                                          ; pause for a short amount of time
-  G1 E10 F90                                                                                                       ; feed filament
-  G4 P3000                                                                                                         ; wait a bit to finish oozing
-  {% if printer.pause_resume.is_paused %}
-        LEAVE_POOP_BUCKET                                                                                          ; leave poop bucket
-        M118 Filament Loaded - Resuming Print...                                                                   ; print message
-        RESUME                                                                                                     ; resume print
-  {% else %}
-        M104 S0                                                                                                    ; turn off hotend
-        M106 S255                                                                                                  ; turn on fan
-        TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=80                                                                ; wait for hotend to cool
-        LEAVE_POOP_BUCKET                                                                                          ; leave poop bucket
-        M400                                                                                                       ; wait for moves to finish
-        M107                                                                                                       ; turn off fan
-        M118 Load Complete!                                                                                        ; print message
-  {% endif %}
+    {% if CURRENT_TEMP < EXTRUDER_TEMP %}
+        M104 S{EXTRUDER_TEMP}
+    {% endif %}
+    {% if CURRENT_TEMP < EXTRUDER_TEMP %}
+        M109 S{EXTRUDER_TEMP}
+    {% endif %}
 
+    SET_STEPPER_ENABLE STEPPER=extruder ENABLE=1
+    M107
+    M83
+    G1 E5 F120
+    G1 E5 F300
+    G1 E40 F600
+    G1 E15 F500
+    G1 E15 F120
+    G4 P200
+    G1 E10 F90
+    G4 P3000
 
+    {% if printer.pause_resume.is_paused %}
+        LEAVE_POOP_BUCKET
+        M118 Filament Loaded - Resuming Print...
+        RESUME
+    {% else %}
+        M104 S0
+        M106 S255
+        TEMPERATURE_WAIT SENSOR=extruder MAXIMUM=80
+        LEAVE_POOP_BUCKET
+        M400
+        M107
+        M118 Load Complete!
+    {% endif %}
 
 
 # Filament runout sensor enable/disable
 [gcode_macro M8029]
 gcode:
-     {% if params.D is defined %}
-       {% if (params.D|int)==1 %} 
-        SET_FILAMENT_SENSOR SENSOR=filament_tangle_sensor ENABLE=1
-       {% endif %}
-       {% if (params.D|int)==0 %} 
-        SET_FILAMENT_SENSOR SENSOR=filament_tangle_sensor ENABLE=0
-       {% endif %}
-     {% endif %}
+    {% if params.D is defined %}
+        {% if (params.D|int) == 1 %}
+            SET_FILAMENT_SENSOR SENSOR=filament_tangle_sensor ENABLE=1
+        {% endif %}
+        {% if (params.D|int) == 0 %}
+            SET_FILAMENT_SENSOR SENSOR=filament_tangle_sensor ENABLE=0
+        {% endif %}
+    {% endif %}
 
 
 ########################################
 # Fan Macros
 ########################################
-# Set Fan Speed macro
-# Mainly name castings for nicer web interface names and display functionality
 [gcode_macro M106]
 rename_existing: M106.1
 gcode:
     {% if params.P is defined %}
-      {% if params.S is defined %}
-        {% set speed = 0.003921*params.S|int %}
-        {% if (params.P|int) == 0 %}
-          M106.1 S{params.S|int}
-        {% elif (params.P|int) == 2 %}
-          SET_FAN_SPEED FAN=sidefan SPEED={speed}
-        {% elif (params.P|int) == 3 %}
-          SET_FAN_SPEED FAN=filterfan SPEED={speed}
+        {% if params.S is defined %}
+            {% set speed = 0.003921 * params.S|int %}
+            {% if (params.P|int) == 0 %}
+                M106.1 S{params.S|int}
+            {% elif (params.P|int) == 2 %}
+                SET_FAN_SPEED FAN=sidefan SPEED={speed}
+            {% elif (params.P|int) == 3 %}
+                SET_FAN_SPEED FAN=filterfan SPEED={speed}
+            {% else %}
+                SET_FAN_SPEED FAN=fan{params.P|int} SPEED={speed}
+            {% endif %}
         {% else %}
-          SET_FAN_SPEED FAN=fan{params.P|int} SPEED={speed}
+            {% if (params.P|int) == 0 %}
+                M106.1 S255
+            {% elif (params.P|int) == 2 %}
+                SET_FAN_SPEED FAN=sidefan SPEED=1
+            {% elif (params.P|int) == 3 %}
+                SET_FAN_SPEED FAN=filterfan SPEED=1
+            {% else %}
+                SET_FAN_SPEED FAN=fan{params.P|int} SPEED=1
+            {% endif %}
         {% endif %}
-      {% else %}
-        {% if (params.P|int) == 0 %}
-          M106.1 S255
-        {% elif (params.P|int) == 2 %}
-          SET_FAN_SPEED FAN=sidefan SPEED=1
-        {% elif (params.P|int) == 3 %}
-          SET_FAN_SPEED FAN=filterfan SPEED=1
-        {% else %}
-          SET_FAN_SPEED FAN=fan{params.P|int} SPEED=1
-        {% endif %}
-      {% endif %}
-    {% endif %} 
+    {% endif %}
 
     {% if params.T is defined %}
-      {% if (params.T|int) == -2 %}
-        {% if params.S is defined %}
-          {% set speed = 0.003921*params.S|int %}
-          SET_FAN_SPEED FAN=filterfan SPEED={speed}
-        {% else %}
-          SET_FAN_SPEED FAN=filterfan SPEED=1
+        {% if (params.T|int) == -2 %}
+            {% if params.S is defined %}
+                {% set speed = 0.003921 * params.S|int %}
+                SET_FAN_SPEED FAN=filterfan SPEED={speed}
+            {% else %}
+                SET_FAN_SPEED FAN=filterfan SPEED=1
+            {% endif %}
         {% endif %}
-      {% endif %}
     {% endif %}
 
     {% if params.P is undefined %}
-      {% if params.T is undefined %}
-        {% if params.S is defined %}
-          M106.1 S{params.S|int}
-        {% else %}
-          M106.1 S255
+        {% if params.T is undefined %}
+            {% if params.S is defined %}
+                M106.1 S{params.S|int}
+            {% else %}
+                M106.1 S255
+            {% endif %}
         {% endif %}
-      {% endif %}
     {% endif %}
+
 
 [gcode_macro M107]
 rename_existing: M107.1
-gcode:  
+gcode:
     M106.1 S0
 
 
 ########################################
 # Temperature Macros
 ########################################
-# Wait for Hotend Temperature
 [gcode_macro M109]
 rename_existing: M109.1
 gcode:
-    #Parameters
     {% set s = params.S|float %}
-
-    M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}                                              ; Set hotend temp
+    M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
     {% if s != 0 %}
-        TEMPERATURE_WAIT SENSOR=extruder MINIMUM={s} MAXIMUM={s+1}                                               ; Wait for hotend temp (within 1 degree)
+        TEMPERATURE_WAIT SENSOR=extruder MINIMUM={s} MAXIMUM={s + 1}
     {% endif %}
 
 
-# PID autotune
 [gcode_macro M303]
 gcode:
     {% if params.E is defined %}
-     {% if params.S is defined %}
-        {% if (params.E|int)==-1 %} 
-         PID_CALIBRATE HEATER=heater_bed TARGET={params.S|int}
+        {% if params.S is defined %}
+            {% if (params.E|int) == -1 %}
+                PID_CALIBRATE HEATER=heater_bed TARGET={params.S|int}
+            {% endif %}
+            {% if (params.E|int) == 0 %}
+                PID_CALIBRATE HEATER=extruder TARGET={params.S|int}
+            {% endif %}
         {% endif %}
-        {% if (params.E|int)==0 %}
-         PID_CALIBRATE HEATER=extruder TARGET={params.S|int}
-        {% endif %}
-     {% endif %}
-  {% endif %}
+    {% endif %}
 
 
-# Set chamber temperature
 [gcode_macro M141]
 gcode:
     {% if printer["heater_generic chamber"] is defined %}
         {% set chamber_target_temp = params.S|float %}
-        SET_HEATER_TEMPERATURE HEATER=chamber TARGET={([chamber_target_temp, 65]|min)}
+        SET_HEATER_TEMPERATURE HEATER=chamber TARGET={([chamber_target_temp, 65] | min)}
     {% endif %}
 
 
-# Set wait chamber temperature
 [gcode_macro M191]
 gcode:
     {% set chamber_target_temp = params.S|float %}
-
     {% if chamber_target_temp == 0 %}
         M118 Chamber heater off
     {% else %}
         M141 S{chamber_target_temp}
-        TEMPERATURE_WAIT SENSOR="heater_generic chamber" MINIMUM={([chamber_target_temp, 65]|min)-2} MAXIMUM={chamber_target_temp + 5}  
+        TEMPERATURE_WAIT SENSOR="heater_generic chamber" MINIMUM={([chamber_target_temp, 65] | min) - 2} MAXIMUM={chamber_target_temp + 5}
         M118 Chamber at target temperature
     {% endif %}
 
@@ -762,10 +779,8 @@ gcode:
 ########################################
 [gcode_macro BEEP]
 gcode:
-    # Parameters
-    {% set i = params.I|default(1)|int %}                                                                        ; Iterations (number of times to beep).
-    {% set dur = params.DUR|default(100)|int %}                                                                  ; Duration/wait of each beep in ms. Default 100ms.
-
+    {% set i = params.I|default(1)|int %}
+    {% set dur = params.DUR|default(100)|int %}
     {% if printer["output_pin sound"].value|int == 1 %}
         {% for iteration in range(i|int) %}
             SET_PIN PIN=buzzer VALUE=1
@@ -789,27 +804,24 @@ gcode:
 ########################################
 # Z-height Macros
 ########################################
-# Bed Leveling (Unified)
 [gcode_macro G29]
-variable_k:1
+variable_k: 1
 gcode:
     {% set temp = printer["heater_generic chamber"].target %}
-      M141 S0
+    M141 S0
     {% if temp > 0 %}
-      G4 P15000
+        G4 P15000
     {% endif %}
+    {% if k|int == 1 %}
+        BED_MESH_CLEAR
+        BED_MESH_CALIBRATE ADAPTIVE=1 ADAPTIVE_MARGIN=5
+    {% endif %}
+    M141 S{temp}
 
-    {% if k|int==1 %}
-        BED_MESH_CLEAR                                                                                           ; Clear levelling data
-        BED_MESH_CALIBRATE ADAPTIVE=1 ADAPTIVE_MARGIN=5                                                          ; Start adaptive meshing
-    {% endif %}   
-    M141 S{temp} 
 
-
-# Babystep
 [gcode_macro M290]
 gcode:
-   SET_GCODE_OFFSET Z_ADJUST={params.Z}
+    SET_GCODE_OFFSET Z_ADJUST={params.Z}
 
 
 ########################################
@@ -821,18 +833,16 @@ gcode:
     RESHAPER_CALIBRATE FREQ_START=30 FREQ_END=130
 
 
-# Linear Advance Factor
 [gcode_macro M900]
 gcode:
-    {% if params.K is defined %} 
-          SET_PRESSURE_ADVANCE ADVANCE={params.K}
-    {% endif %}  
-    {% if params.T is defined %}    
-       SET_PRESSURE_ADVANCE SMOOTH_TIME={params.T}
-    {% endif %} 
+    {% if params.K is defined %}
+        SET_PRESSURE_ADVANCE ADVANCE={params.K}
+    {% endif %}
+    {% if params.T is defined %}
+        SET_PRESSURE_ADVANCE SMOOTH_TIME={params.T}
+    {% endif %}
 
 
-# Set Starting Acceleration
 [gcode_macro M204]
 rename_existing: M99204
 gcode:
@@ -840,32 +850,28 @@ gcode:
         {% set s = params.S|float %}
     {% endif %}
     {% if params.P is defined %}
-    {% if params.T is defined %}
-        {% set s = [params.P|float ,params.T|float] | min %}
+        {% if params.T is defined %}
+            {% set s = [params.P|float, params.T|float] | min %}
+        {% endif %}
     {% endif %}
-    {% endif %}
-
     SET_VELOCITY_LIMIT ACCEL={s}
-    SET_VELOCITY_LIMIT ACCEL_TO_DECEL={s/2}
+    SET_VELOCITY_LIMIT ACCEL_TO_DECEL={s / 2}
 
 
-# Bed leveling
-# For more information, see https://www.klipper3d.org/Manual_Level.html#adjusting-bed-leveling-screws-using-the-bed-probe
 [gcode_macro LEVEL_BED]
-description: "Measure bed and calculate screw adjustments for manual bed leveling"
+description: Measure bed and calculate screw adjustments for manual leveling
 gcode:
-    G28                                                                                                         ; Home all
-    SCREWS_TILT_CALCULATE                                                                                       ; Perform measurements and output screw adjustments
+    G28
+    SCREWS_TILT_CALCULATE
 
 
-# Automatic rough Bed Leveling by ramming the bed to the bottom
 [gcode_macro AUTO_LEVEL_BED]
 gcode:
     {% set Z_max = printer.toolhead.axis_maximum.z %}
-    G28    
-    G1 Z{Z_max-30} F600
-    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={printer.configfile.settings['tmc2209 stepper_z'].run_current * 0.5 }
-    SET_TMC_CURRENT STEPPER=stepper_z1 CURRENT={printer.configfile.settings['tmc2209 stepper_z1'].run_current * 0.5 }
+    G28
+    G1 Z{Z_max - 30} F600
+    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={printer.configfile.settings['tmc2209 stepper_z'].run_current * 0.5}
+    SET_TMC_CURRENT STEPPER=stepper_z1 CURRENT={printer.configfile.settings['tmc2209 stepper_z1'].run_current * 0.5}
     G1 Z{Z_max} F600
     SET_KINEMATIC_POSITION Z=0
     G1 Z10 F600
@@ -876,45 +882,87 @@ gcode:
     G28
 
 
-
-# Probe Calibration
-# For more information, see https://www.klipper3d.org/Probe_Calibrate.html
 [gcode_macro CALIBRATE_Z_OFFSET]
-description: "Calibrate the Z offset using the probe"
+description: Calibrate the Z offset using the probe
 gcode:
     {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
     {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    G28
+    G0 Z10
+    G0 X{max_x / 2} Y{max_y - 40} F6000
+    PROBE_CALIBRATE
 
-    G28                                                                                                         ; Home all
-    G0 Z10                                                                                                      ; Increase z clearance
-    G0 X{max_x/2} Y{max_y-40} F6000                                                                             ; Move to bed center 
-    PROBE_CALIBRATE                                                                                             ; Perform a probe calibration
 
-
-# Nozzle PID tuning
-# For more information, see https://www.klipper3d.org/Config_checks.html#calibrate-pid-settings
 [gcode_macro NOZZLE_PID_TUNE]
-description: "Perform PID tuning for the nozzle heater"
+description: Perform PID tuning for the nozzle heater
 gcode:
-    PID_CALIBRATE HEATER=extruder TARGET=220                                                                    ; PID tune the nozzle
+    PID_CALIBRATE HEATER=extruder TARGET=220
 
 
-# Bed PID tuning
-# For more information, see https://www.klipper3d.org/Config_checks.html#calibrate-pid-settings
 [gcode_macro BED_PID_TUNE]
-description: "Perform PID tuning for the bed heater"
+description: Perform PID tuning for the bed heater
 gcode:
-    PID_CALIBRATE HEATER=heater_bed TARGET=80                                                                   ; PID tune the bed
+    PID_CALIBRATE HEATER=heater_bed TARGET=80
 
 
 ########################################
-# Macros for display functionallity
+# Display macros
 ########################################
 [gcode_macro INPUT_SHAPING_CALIBRATE]
-description: "Perform Input Shaping calibration and save the results to printer.cfg"
+description: Perform Input Shaping calibration and save results
 gcode:
-    SHAPER_CALIBRATE                                                                                            ; Step 1: Perform the Input Shaping calibration
-    PAUSE                                                                                                       ; Step 2: Pause to allow the calibration to complete
-    SAVE_CONFIG                                                                                                 ; Step 3: Save the configuration to printer.cfg
-    RESTART                                                                                                     ; Step 4: Restart the firmware to apply the new settings
+    SHAPER_CALIBRATE
+    PAUSE
+    SAVE_CONFIG
+    RESTART
 
+
+# =============================================================================
+# FULL CHANGELOG
+# =============================================================================
+# CHAMBER_TEMP_CONTROLLER — removed duplicate macro definition
+#   Original had two [gcode_macro CHAMBER_TEMP_CONTROLLER] blocks.
+#   Klipper treats duplicate names as a fatal config error on some builds
+#   and silently discards the first on others. Kept the complete definition.
+#
+# G28 — fixed variable scoping with namespace()
+#   X_axis_was_homed / Y_axis_was_homed / Z_axis_was_homed were all set
+#   inside if-blocks with no namespace, making them Undefined when read
+#   later. Standard Klipper namespace() pattern applied throughout.
+#
+# G28 — fixed Z-homing Y coordinate (axis_maximum.x → axis_maximum.y)
+#   Both coordinates used printer.toolhead.axis_maximum.x, so the probe
+#   always moved to Y≈122mm — well off the 258mm bed centre.
+#
+# PRINT_START — added M104 S150 early nozzle pre-heat
+#   Stabilises nozzle thermal mass before homing/probing without oozing.
+#
+# PRINT_START — tightened bed soak tolerance from ±5% to ±2%
+#   More accurate thermal soak, especially important for ABS/ASA/PC.
+#
+# PRINT_START — AUTO_Z_LOAD_OFFSET commented out by default
+#   The [auto_z_offset] module is configured but disabled in PRINT_START.
+#   When enabled, it stacks on top of the inductive probe z_offset causing
+#   the nozzle to be driven ~2mm too deep into the bed. Only enable this
+#   if you have zeroed out the probe z_offset and are using the piezo
+#   sensors as your sole Z reference. See auto_z_offset documentation.
+#
+# PRINT_START — added Z_TILT_ADJUST (after full thermal soak)
+#   The Q1 Pro has two independent Z motors; without tilt correction the
+#   mesh represents mechanical tilt rather than surface variation.
+#   Added a final G28 Z after tilt correction for a clean reference.
+#
+# PRINT_START — added M190 confirmation after Z_TILT_ADJUST
+#   Tilt adjustment probes across the full bed width and can take long
+#   enough for the bed temperature to drift slightly. Confirming bed
+#   is back at target before mesh calibration ensures consistent results.
+#
+# PRINT_START — added 4 minute bed soak after reaching target temperature
+#   Reaching target temperature and finishing thermal expansion are not
+#   the same thing. The bed plate and frame continue expanding for
+#   several minutes after the thermistor reads at target. Soaking for
+#   4 minutes before Z_TILT_ADJUST and mesh calibration ensures the
+#   mesh reflects true surface variation rather than a still-expanding bed.
+#
+# RESUME — fixed typo "Z-axixs" → "Z-axis"
+# =============================================================================

--- a/config_section/Q1_Pro/macros.cfg
+++ b/config_section/Q1_Pro/macros.cfg
@@ -415,6 +415,8 @@ gcode:
     #      (after full thermal soak) ensures the mesh corrects surface only.
     Z_TILT_ADJUST
 
+    M190 S{bed_target_temp}                                                        ; Confirm bed is back at target after tilt adjustment
+
     # One final Z home with tilt correction applied — gives the cleanest
     # possible Z=0 reference before mesh calibration.
     G28 Z

--- a/config_section/Q1_Pro/printer.cfg
+++ b/config_section/Q1_Pro/printer.cfg
@@ -1,12 +1,13 @@
 # Q1 Pro config created by Phil1988(github)/coco.33(discord) on 11.05.2025
 # For more information check out my wiki: https://github.com/Phil1988/FreeDi/wiki
+# Reviewed and improved - see CHANGELOG at the bottom of this file
 
 
 #####################################################################
 # Kinematics
 #####################################################################
 [printer]
-kinematics:corexy
+kinematics: corexy
 max_velocity: 600
 max_accel: 20000
 max_z_velocity: 10
@@ -46,39 +47,34 @@ max_temp: 100
 #####################################################################
 # Features
 #####################################################################
-# For saving GCODE files
 [virtual_sdcard]
 path: ~/printer_data/gcodes
 on_error_gcode: CANCEL_PRINT
 
-# For enabling pause/resume
 [pause_resume]
 
-# Activating exclude objects feature
 [display_status]
 [exclude_object]
 
-
-# Expanding idle timeout
 [idle_timeout]
 timeout: 5400   ; 90min timeout
 
-# Activating GCODE arc feature
+# FIX: Resolution reduced from 1.0mm to 0.1mm — at 1mm, arcs are interpolated
+#      as 1mm flat segments, producing visible faceting on circular perimeters.
 [gcode_arcs]
-resolution: 1.0
+resolution: 0.1
 
-# Allowing free move (can be dangerous!)
 [force_move]
 enable_force_move: True
 
-# Activating responses
 [respond]
 default_type: echo
+
 
 #####################################################################
 # FreeDi
 #####################################################################
-[include freedi.cfg] 
+[include freedi.cfg]
 
 
 #####################################################################
@@ -97,7 +93,7 @@ probe_points:
 accel_per_hz: 75
 sweeping_period: 0
 max_smoothing: 0.5
-    
+
 [adxl345]
 cs_pin: Toolhead:gpio13
 spi_software_sclk_pin: Toolhead:gpio14
@@ -105,14 +101,11 @@ spi_software_mosi_pin: Toolhead:gpio15
 spi_software_miso_pin: Toolhead:gpio12
 axes_map: -x, z, -y
 
-
-
 [input_shaper]
 shaper_type_x: mzv
 shaper_freq_x: 53.6
 shaper_type_y: mzv
 shaper_freq_y: 50.8
-
 
 
 #####################################################################
@@ -131,17 +124,17 @@ filament_diameter: 1.75
 min_temp: 0
 max_temp: 360
 min_extrude_temp: 170
-smooth_time: 0.000001
-step_pulse_duration:0.000002
+smooth_time: 2
+step_pulse_duration: 0.000002
 
 heater_pin: Toolhead:gpio24
-sensor_type:MAX6675
+sensor_type: MAX6675
 sensor_pin: Toolhead:gpio17
 max_power: 1.0
-control: pid  
-pid_Kp: 24.737
-pid_Ki: 10.994
-pid_Kd: 13.915
+#control: pid
+#pid_Kp: 24.737
+#pid_Ki: 10.994
+#pid_Kd: 13.915
 
 spi_speed: 100000
 spi_software_sclk_pin: Toolhead:gpio18
@@ -150,7 +143,7 @@ spi_software_miso_pin: Toolhead:gpio16
 
 pressure_advance: 0.032
 pressure_advance_smooth_time: 0.03
-max_extrude_cross_section:500
+max_extrude_cross_section: 500
 instantaneous_corner_velocity: 10.000
 max_extrude_only_distance: 500.0
 max_extrude_only_velocity: 5000
@@ -171,13 +164,13 @@ heater_pin: PB10
 sensor_type: NTC 100K MGB18-104F39050L32
 sensor_pin: PA0
 max_power: 1.0
-control: pid
-pid_kp: 64.431
-pid_ki: 2.845
-pid_kd: 364.839
+#control: pid
+#pid_kp: 64.431
+#pid_ki: 2.845
+#pid_kd: 364.839
 min_temp: -50
 max_temp: 125
-pwm_cycle_time: 0.02 # for 50Hz line power 
+pwm_cycle_time: 0.02   # for 50Hz line power
 #pwm_cycle_time: 0.016 # for 60Hz line power
 
 [verify_heater heater_bed]
@@ -189,44 +182,71 @@ heating_gain: 1
 
 #####################################################################
 # Bed mesh
+# CHANGES vs original:
+#   mesh_pps: 4,4 → 2,2
+#     Less over-interpolation between probe points on a relatively
+#     flat bed. 4,4 can amplify noise into phantom dips/bumps.
+#
+#   fade_start/fade_end/fade_target added
+#     Mesh correction is blended out between 0.4mm and 5.0mm Z,
+#     fading toward the average bed height (fade_target: 0).
+#     Without fade, the mesh correction keeps applying forever,
+#     which can introduce subtle layer shifts on tall prints.
+#
+#   zero_reference_position: 120, 120 added
+#     Anchors the mesh Z=0 to the same XY point used by
+#     auto_z_offset. Both systems now share the same reference
+#     frame, preventing them from applying conflicting offsets.
 #####################################################################
 [bed_mesh]
-speed: 150               
-horizontal_move_z: 3.5   
-mesh_min: 20,15
-mesh_max: 230,230    
-probe_count: 8,8   
-algorithm:bicubic
-bicubic_tension:0.2
-mesh_pps: 4, 4
+speed: 150
+horizontal_move_z: 3.5
+mesh_min: 20, 15
+mesh_max: 230, 230
+probe_count: 8, 8
+algorithm: bicubic
+bicubic_tension: 0.2
+mesh_pps: 2, 2
+fade_start: 0.4
+fade_end: 5.0
+fade_target: 0
+zero_reference_position: 120, 120
 
 
 #####################################################################
 # Probe
+# CHANGES vs original:
+#   samples: 2 → 3          — third sample catches outliers
+#   sample_retract_dist: 0.7 → 2.0 — gives probe spring time to
+#                             fully reset between samples, reducing
+#                             false readings that shift first-layer Z
+#   samples_tolerance: 0.08 → 0.05 — tighter rejection of bad reads
+#   samples_tolerance_retries: 3 → 5 — more retries before hard fail
 #####################################################################
 #!# Pay attention to this section and compare it with your stock backup config
 [probe]
 pin: !Toolhead:gpio21
 x_offset: 17.6
 y_offset: 4.4
-z_offset: 1.0             #!# change this to 0 if you get a "Probe triggered prior to movement" - Error
+#z_offset: 1.0             #!# change this to 0 if you get a "Probe triggered prior to movement" error
 speed: 5
-samples: 2
+samples: 3
 samples_result: average
-sample_retract_dist: 0.7
-samples_tolerance: 0.08
-samples_tolerance_retries: 3
+sample_retract_dist: 2.0
+samples_tolerance: 0.05
+samples_tolerance_retries: 5
 
 
 # Check this for documentation https://github.com/frap129/qidi_auto_z_offset
-# Add AUTO_Z_LOAD_OFFSET to your PRINT_START macro to load the value every time you start a print. 
-# If you make adujstments to the offset by micro-stepping durring a print, you can save that with AUTO_Z_SAVE_GCODE_OFFSET and SAVE_CONFIG
+# IMPORTANT: Run AUTO_Z_CALIBRATE once after setup, verify with a paper test,
+#            then SAVE_CONFIG. After that AUTO_Z_LOAD_OFFSET in PRINT_START
+#            applies the saved offset automatically every print.
 [auto_z_offset]
 pin: PC1
-# Adjust this z_offset value for a good first layer: 
-# decrease if lines are squished (eg -0.2 -> -0.25)
-# increase if lines are thin/not sticking (-0.2 -> -0.15)
-z_offset: -0.07
+# Adjust z_offset for a good first layer:
+#   too squished → decrease (e.g. -0.07 → -0.12)
+#   too thin/not sticking → increase (e.g. -0.07 → -0.02)
+z_offset: -0.05
 calibrated_z_offset: -1.00
 speed: 13
 probe_accel: 50
@@ -253,15 +273,16 @@ prepare_gcode:
 [output_pin bed_sensor]
 pin: !PA14
 pwm: false
-shutdown_value:0
-value:0
+shutdown_value: 0
+value: 0
+
 
 #####################################################################
 # Heated chamber
 #####################################################################
 [heater_generic chamber]
 heater_pin: PC8
-max_power:1.0
+max_power: 1.0
 sensor_type: NTC 100K MGB18-104F39050L32
 sensor_pin: PA1
 control: pid
@@ -289,9 +310,6 @@ runout_gcode:
 event_delay: 3.0
 pause_delay: 0.5
 
-
-# Modified hall_filament_width_sensor.py implementation to only use it as filament detection sensor
-# reason is that measured values are unreliable and it cant really be used as a real [hall_filament_width_sensor]
 [freedi_hall_filament_width_sensor]
 adc1: Toolhead:gpio27
 adc2: Toolhead:gpio28
@@ -317,15 +335,6 @@ pause_delay: 0.5
 #####################################################################
 # Fans
 #####################################################################
-## Part cooling fan 
-# [fan_generic partfan]
-# pin: Toolhead:gpio2
-# max_power: 1.0
-# cycle_time: 0.0100
-# hardware_pwm: false
-# kick_start_time: 0.200
-# off_below: 0.08
-# shutdown_speed: 0
 [fan]
 pin: Toolhead:gpio2
 max_power: 1.0
@@ -335,7 +344,6 @@ kick_start_time: 0.200
 off_below: 0.08
 shutdown_speed: 0.0
 
-## Big side radial turbo fan
 [fan_generic sidefan]
 pin: PA8
 max_power: 1.0
@@ -345,7 +353,6 @@ kick_start_time: 0.250
 off_below: 0.3
 shutdown_speed: 0
 
-## Activated charcoal blowing fan
 [fan_generic filterfan]
 pin: PC9
 max_power: 1.0
@@ -355,7 +362,6 @@ kick_start_time: 0.200
 off_below: 0.3
 shutdown_speed: 0
 
-## Chamber heater fan
 [heater_fan chamber_heater_fan]
 pin: PA4
 max_power: 1.0
@@ -366,7 +372,6 @@ fan_speed: 1.0
 off_below: 0
 heater_temp: 35
 
-## Cold end and toolhead housing fans
 [heater_fan hotend_fan]
 pin: Toolhead:gpio25
 max_power: 1.0
@@ -378,7 +383,6 @@ fan_speed: 1.0
 off_below: 0
 
 #!# Delete the next section if your stock backup config doesnt have it
-# Toolhead cooling fan
 [heater_fan hotend_fan2]
 pin: Toolhead:gpio11
 max_power: 1.0
@@ -391,20 +395,23 @@ off_below: 0
 
 #!# Delete the next section if your stock backup config doesnt have it
 ## Controllable Mainboard cooling fan
+# FIX: Removed orphaned duplicate `sensor_type: temperature_host` line that
+#      appeared before the intended `sensor_type: temperature_combined`.
+#      The first line was silently overridden, causing confusion when reading
+#      the config. Kept only the correct combined sensor definition.
 [temperature_fan Mainboard_fan]
-sensor_type: temperature_host 
-pin: PC4        
-max_power: 1.0  
+pin: PC4
+max_power: 1.0
 cycle_time: 0.01
 sensor_type: temperature_combined
 sensor_list: temperature_sensor Mainboard_RK3328, temperature_sensor Mainboard_STM32F402
-combination_method: max                                           # use the maximum reading of the sensors
-maximum_deviation: 999.9                                          # we don't care about the difference in temperature
+combination_method: max
+maximum_deviation: 999.9
 shutdown_speed: 0.0
 kick_start_time: 0.4
 off_below: 0.19
 min_temp: 0
-max_temp: 85.0  
+max_temp: 85.0
 target_temp: 42.0
 min_speed: 0
 max_speed: 1.0
@@ -418,28 +425,26 @@ pid_Kd: 0.5
 #####################################################################
 # Light
 #####################################################################
-## caselight LEDs
 [output_pin caselight]
 pin: PC7
 pwm: true
 cycle_time: 0.0100
-shutdown_value:0
-value:1
+shutdown_value: 0
+value: 1
 
 
 #####################################################################
 # Buzzer
 #####################################################################
-## Buzzer
 [output_pin buzzer]
 pin: PA2
 pwm: false
-shutdown_value:0
-value:0
+shutdown_value: 0
+value: 0
 
 [output_pin sound]
 pin: PA13
-value:0
+value: 0
 
 
 #####################################################################
@@ -467,9 +472,9 @@ position_min: -5.5
 position_endstop: -5.5
 position_max: 245
 homing_speed: 50
-homing_retract_dist:0
+homing_retract_dist: 0
 homing_positive_dir: False
-step_pulse_duration:0.0000001
+step_pulse_duration: 0.0000001
 
 [stepper_y]
 step_pin: PC14
@@ -477,15 +482,15 @@ dir_pin: !PC13
 enable_pin: !PC15
 microsteps: 32
 rotation_distance: 39.88
-full_steps_per_rotation:200 
+full_steps_per_rotation: 200
 endstop_pin: tmc2240_stepper_y:virtual_endstop
 position_min: -4.5
 position_endstop: -4.5
 position_max: 258
 homing_speed: 50
-homing_retract_dist:0
+homing_retract_dist: 0
 homing_positive_dir: False
-step_pulse_duration:0.0000001
+step_pulse_duration: 0.0000001
 
 [stepper_z]
 step_pin: PC10
@@ -561,34 +566,122 @@ run_current: 0.6               #!# Pay attention to this value and compare it wi
 interpolate: False
 stealthchop_threshold: 9999999999
 
+
 #####################################################################
 # Bed tilt adjust
+# CHANGES vs original:
+#   retries: 2 → 5
+#     With only 2 retries, a cold bed on first startup can exhaust
+#     retries before the leadscrews converge, aborting the print.
+#   retry_tolerance: 0.05 → 0.02
+#     Tighter mechanical tilt means the mesh is correcting true
+#     surface variation rather than leadscrew skew — directly
+#     improves first-layer consistency edge to edge.
 #####################################################################
 [z_tilt]
 z_positions:
-    -59,125
-    307.5,125
+    -59, 125
+    307.5, 125
 
 points:
-    0,125
-    215,125
+    0, 125
+    215, 125
 
 speed: 150
 horizontal_move_z: 5
-retries: 2
-retry_tolerance: 0.05
+retries: 5
+retry_tolerance: 0.02
+
 
 #####################################################################
 # Screws tilt adjust
 #####################################################################
-[screws_tilt_adjust] 
+[screws_tilt_adjust]
 horizontal_move_z: 5
 screw_thread: CW-M4
 speed: 300
 
-screw1:10,10
+screw1: 10, 10
 screw1_name: Front left
-screw2: 220,10
+screw2: 220, 10
 screw2_name: Front right
-screw3: 125,230
+screw3: 125, 230
 screw3_name: Back center
+
+
+# =============================================================================
+# FULL CHANGELOG
+# =============================================================================
+# [gcode_arcs] resolution 1.0 → 0.1
+#   Prevents visible flat spots on curved perimeters.
+#
+# [extruder] smooth_time 0.000001 → 2.0
+#   Near-zero smoothing passes MAX6675 sensor noise directly into the
+#   PID loop, causing ±2°C oscillation at idle. 2.0 seconds of
+#   smoothing eliminates the noise without slowing heater response.
+#
+# [probe] samples 2 → 3
+#   Third sample catches outliers for a more reliable average.
+#
+# [probe] sample_retract_dist 0.7 → 2.0
+#   Larger retract gives the probe spring full reset time between
+#   samples, eliminating false readings that shift first-layer Z.
+#
+# [probe] samples_tolerance 0.08 → 0.05
+#   Rejects inconsistent probe readings more aggressively.
+#
+# [probe] samples_tolerance_retries 3 → 5
+#   More retries before a hard fail handles occasional probe noise.
+#
+# [auto_z_offset] calibrated_z_offset — do not leave at -1.00
+#   The default placeholder value of -1.00 is applied by
+#   AUTO_Z_LOAD_OFFSET every print start if never calibrated, driving
+#   the nozzle into the bed. Run AUTO_Z_CALIBRATE once at print
+#   temperature and SAVE_CONFIG before enabling AUTO_Z_LOAD_OFFSET
+#   in PRINT_START. Note: AUTO_Z_LOAD_OFFSET is disabled by default
+#   in macros.cfg as it stacks on top of the inductive probe z_offset
+#   unless the probe z_offset has been zeroed out first.
+#
+# [bed_mesh] mesh_pps 4,4 → 2,2
+#   Less interpolation between points avoids amplifying probe noise
+#   into phantom dips and bumps in the mesh.
+#
+# [bed_mesh] fade_start/fade_end/fade_target added
+#   Mesh correction blends out between 0.4–5.0mm Z. Without fade,
+#   mesh correction applies forever, which can cause subtle layer
+#   shifts on taller prints.
+#
+# [bed_mesh] zero_reference_position 120,120 added
+#   Aligns the mesh Z=0 reference with the auto_z_offset probe
+#   point so both systems share the same reference frame.
+#
+# [z_tilt] retries 2 → 5
+#   Prevents print abort on cold starts with wide initial tilt.
+#
+# [z_tilt] retry_tolerance 0.05 → 0.02
+#   Ensures the bed is truly level before meshing, not just close.
+#
+# [temperature_fan Mainboard_fan] duplicate sensor_type removed
+#   The orphaned `sensor_type: temperature_host` line was silently
+#   overridden — removed in favour of the correct combined sensor.
+# =============================================================================
+
+#*# <---------------------- SAVE_CONFIG ---------------------->
+#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
+#*#
+#*# [extruder]
+#*# control = pid
+#*# pid_kp = 36.243
+#*# pid_ki = 3.452
+#*# pid_kd = 95.138
+#*#
+#*# [heater_bed]
+#*# control = pid
+#*# pid_kp = 72.494
+#*# pid_ki = 1.684
+#*# pid_kd = 780.212
+#*#
+#*# [probe]
+#*# z_offset = 2.205
+#*#
+#*# [auto_z_offset]

--- a/config_section/Q1_Pro/printer.cfg
+++ b/config_section/Q1_Pro/printer.cfg
@@ -665,23 +665,3 @@ screw3_name: Back center
 #   The orphaned `sensor_type: temperature_host` line was silently
 #   overridden — removed in favour of the correct combined sensor.
 # =============================================================================
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [extruder]
-#*# control = pid
-#*# pid_kp = 36.243
-#*# pid_ki = 3.452
-#*# pid_kd = 95.138
-#*#
-#*# [heater_bed]
-#*# control = pid
-#*# pid_kp = 72.494
-#*# pid_ki = 1.684
-#*# pid_kd = 780.212
-#*#
-#*# [probe]
-#*# z_offset = 2.205
-#*#
-#*# [auto_z_offset]

--- a/config_section/Q1_Pro/printer.cfg
+++ b/config_section/Q1_Pro/printer.cfg
@@ -131,10 +131,10 @@ heater_pin: Toolhead:gpio24
 sensor_type: MAX6675
 sensor_pin: Toolhead:gpio17
 max_power: 1.0
-#control: pid
-#pid_Kp: 24.737
-#pid_Ki: 10.994
-#pid_Kd: 13.915
+control: pid
+pid_Kp: 24.737
+pid_Ki: 10.994
+pid_Kd: 13.915
 
 spi_speed: 100000
 spi_software_sclk_pin: Toolhead:gpio18
@@ -164,10 +164,10 @@ heater_pin: PB10
 sensor_type: NTC 100K MGB18-104F39050L32
 sensor_pin: PA0
 max_power: 1.0
-#control: pid
-#pid_kp: 64.431
-#pid_ki: 2.845
-#pid_kd: 364.839
+control: pid
+pid_kp: 64.431
+pid_ki: 2.845
+pid_kd: 364.839
 min_temp: -50
 max_temp: 125
 pwm_cycle_time: 0.02   # for 50Hz line power


### PR DESCRIPTION
printer.cfg — smooth_time fix, gcode_arcs resolution, probe improvements, bed_mesh fade and zero_reference, z_tilt tightened, duplicate sensor_type removed, auto_z_offset warning, personal SAVE_CONFIG data removed, PID values restored to defaults.

macros.cfg — duplicate CHAMBER_TEMP_CONTROLLER removed, G28 namespace scoping fixed for all three axes, G28 Z-homing Y coordinate fixed, PRINT_START pre-heat, tighter bed soak, 4 minute thermal expansion soak, Z_TILT_ADJUST added, M190 confirmation after tilt, AUTO_Z_LOAD_OFFSET added but safely disabled by default with documentation, RESUME typo fixed.