### PR TITLE
Increase max_difference in the hall width sensor

### DIFF
--- a/config_section/Plus4/printer.cfg
+++ b/config_section/Plus4/printer.cfg
@@ -313,7 +313,7 @@ cal_dia2: 2.0
 raw_dia1: 14206
 raw_dia2: 15278
 default_nominal_filament_diameter: 1.75
-max_difference: 0.00
+max_difference: 0.5
 measurement_delay: 50
 enable: True
 enable_flow_compensation: False

--- a/config_section/Q1_Pro/printer.cfg
+++ b/config_section/Q1_Pro/printer.cfg
@@ -297,7 +297,7 @@ cal_dia2: 2.0
 raw_dia1: 14206
 raw_dia2: 15278
 default_nominal_filament_diameter: 1.75
-max_difference: 0.00
+max_difference: 0.5
 measurement_delay: 50
 enable: True
 enable_flow_compensation: False

--- a/config_section/template/printer.cfg
+++ b/config_section/template/printer.cfg
@@ -313,7 +313,7 @@ cal_dia2: 2.0
 raw_dia1: 14206
 raw_dia2: 15278
 default_nominal_filament_diameter: 1.75
-max_difference: 0.00
+max_difference: 0.5
 measurement_delay: 50
 enable: True
 enable_flow_compensation: False


### PR DESCRIPTION
Need a value greater than 0 to prevent runout false positives when detected width is greater than the nominal width. A value of `0.5` means that the sensor will allow values up to 2.25 before triggering the runout switch.