### PR TITLE
fix(auto_z_offset): replace invalid Coord tuple init with proper args

### DIFF
--- a/klipper_module/qidi_auto_z_offset/auto_z_offset.py
+++ b/klipper_module/qidi_auto_z_offset/auto_z_offset.py
@@ -24,7 +24,7 @@ class AutoZOffsetCommandHelper(probe.ProbeCommandHelper):
         self.calibrated_z_offset = config.getfloat("calibrated_z_offset", 0.0)
         self.last_state = False
         self.last_z_result = 0.0
-        self.last_probe_position = gcode.Coord((0., 0., 0.))
+        self.last_probe_position = gcode.Coord(0., 0., 0., 0.)
 
         # Register commands
         self.gcode = self.printer.lookup_object("gcode")


### PR DESCRIPTION
Fix incompatibility with current Klipper API where gcode.Coord expects separate x, y, z, e arguments instead of a tuple, preventing startup crash during module initialization.
https://github.com/Phil1988/FreeDi/issues/517