### PR TITLE
 PAUSE/RESUME/CANCEL_PRINT safeguards and reliability fixes across all machine profiles

### DIFF
--- a/config_section/Plus4/macros.cfg
+++ b/config_section/Plus4/macros.cfg
@@ -560,13 +560,16 @@ gcode:
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
 gcode:
-    {% set z_hop = params.Z|default(30)|int %}                                                                     ; Z hop amount
-    
-    {% if printer['pause_resume'].is_paused|int == 0 %}     
+    {% set z_hop = params.Z|default(30)|float %}                                                                   ; Z hop amount
+    {% set z_hop = [z_hop, 0.0]|max %}                                                                             ; Prevent negative Z hop input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if pause_state == 0 %}
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}                                                ; Set Z hop variable for reference in resume macro
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}                          ; Set hotend temperature variable for reference in resume macro
         SAVE_GCODE_STATE NAME=PAUSE                                                                                ; Save current position for resume
         BASE_PAUSE                                                                                                 ; Pause print
+        M400                                                                                                       ; Flush queued moves before parking
         {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}                         ; Check that Z hop doesn't exceed Z max
             G91                                                                                                    ; Use Relative positioning
             G1 Z{z_hop} F600                                                                                       ; Raise Z up by Z hop amount
@@ -575,11 +578,14 @@ gcode:
         {% endif %}
         SAVE_GCODE_STATE NAME=PAUSEPARK2
         G90                                                                                                        ; Absolute positioning
-        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead  at rear center
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead at rear center
         SAVE_GCODE_STATE NAME=PAUSEPARK                                                                            ; Save parked position in case toolhead is moved during the pause (otherwise the return zhop can error)
         M104 S0                                                                                                    ; Turn off hotend
         SET_IDLE_TIMEOUT TIMEOUT=43200                                                                             ; Set timeout to 12 hours
         SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0                                                               ; Disable extruder stepper
+        M400                                                                                                       ; Ensure parking moves are complete before returning
+    {% else %}
+        RESPOND MSG="PAUSE: Print already paused"                                                                  ; Avoid re-running the pause sequence twice
     {% endif %}
 
 
@@ -588,14 +594,15 @@ rename_existing: BASE_RESUME
 variable_zhop: 0
 variable_etemp: 0
 gcode:
-    {% set extrusion_length = params.E|default(2.5)|int %}                                                         ; Hotend prime amount (in mm)
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 1 %}
-        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; check if z position is lost
-            {action_raise_error("ERROR: Z-axixs lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
+    {% if pause_state == 1 %}
+        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; Check if Z position is lost
+            {action_raise_error("ERROR: Z-axis lost its position (Idle-Timeout)! Resume not possible - print should be aborted.")}
         {% endif %}
-        
+
         SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
+        M400                                                                                                       ; Flush queued moves before restoring state
 
         # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE                                                                                     
         {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}                  ; If X/Y position is lost, but z is still OK
@@ -606,11 +613,17 @@ gcode:
 
         PRIME_NOZZLE HOTEND_TARGET_TEMP={etemp}                                                                    ; Prime nozzle with last used hotend temperature
 
-        M109 S{etemp}                                                                                              ; Wait for hotend to heat up
+        {% if etemp > 0 %}
+            M109 S{etemp|int}                                                                                      ; Wait for hotend to heat up
+        {% endif %}
 
         RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150                                                  ; Return to position after Z-hop (safely above the part)       
+        M400                                                                                                        ; Flush queued moves before final restore
         RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                        ; Restore position
-        BASE_RESUME                                                                                                ; Absolute positioning
+        M400                                                                                                        ; Ensure the final state restore is complete before resuming
+        BASE_RESUME                                                                                                ; Resume print
+    {% else %}
+        RESPOND MSG="RESUME: Print not paused"                                                                      ; Avoid re-running the resume sequence twice
     {% endif %}
 
 
@@ -618,21 +631,32 @@ gcode:
 rename_existing: BASE_CANCEL_PRINT
 gcode:
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
-    {% if (printer.toolhead.position.z + 12) < max_z %}
-        {% set z_hop = 2  %}
+    {% set print_state = printer.print_stats.state|string|lower %}
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if print_state not in ["printing", "paused"] and pause_state == 0 %}
+        RESPOND MSG="CANCEL_PRINT: No active print to cancel"                                                       ; Avoid running the cancel sequence for a non-active job
+        BASE_CANCEL_PRINT
     {% else %}
-        {% set z_hop = 0 %}
+        {% if (printer.toolhead.position.z + 2) < max_z %}
+            {% set z_hop = 2  %}
+        {% else %}
+            {% set z_hop = 0 %}
+        {% endif %}
+
+        M400                                                                                                        ; Flush queued moves before cancel cleanup
+        G91                                                                                                         ; Relative positioning
+        G1 Z{z_hop} F600                                                                                            ; Do a tiny z-hop
+        G90                                                                                                         ; Absolute positioning
+
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
+        M400                                                                                                        ; Wait for the parking move to finish
+        CLEAR_PAUSE                                                                                                 ; Clear pause state before shutdown
+
+        PRINT_END
+        M400                                                                                                        ; Ensure shutdown moves are complete before canceling
+        BASE_CANCEL_PRINT
     {% endif %}
-
-    G91                                                                                                            ; Relative positioning
-    G1 Z{z_hop} F600                                                                                               ; Do a tiny z-hop
-    G90                                                                                                            ; Absolute positioning
-
-    G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
-    CLEAR_PAUSE
-
-    PRINT_END
-    BASE_CANCEL_PRINT
 
 
 [gcode_macro _Z_CLEARANCE]

--- a/config_section/Q1_Pro/macros.cfg
+++ b/config_section/Q1_Pro/macros.cfg
@@ -435,13 +435,16 @@ gcode:
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
 gcode:
-    {% set z_hop = params.Z|default(30)|int %}                                                                     ; Z hop amount
-    
-    {% if printer['pause_resume'].is_paused|int == 0 %}     
+    {% set z_hop = params.Z|default(30)|float %}                                                                   ; Z hop amount
+    {% set z_hop = [z_hop, 0.0]|max %}                                                                             ; Prevent negative Z hop input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if pause_state == 0 %}
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}                                                ; Set Z hop variable for reference in resume macro
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}                          ; Set hotend temperature variable for reference in resume macro
         SAVE_GCODE_STATE NAME=PAUSE                                                                                ; Save current position for resume
         BASE_PAUSE                                                                                                 ; Pause print
+        M400                                                                                                       ; Flush queued moves before parking
         {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}                         ; Check that Z hop doesn't exceed Z max
             G91                                                                                                    ; Use Relative positioning
             G1 Z{z_hop} F600                                                                                       ; Raise Z up by Z hop amount
@@ -455,6 +458,9 @@ gcode:
         M104 S0                                                                                                    ; Turn off hotend
         SET_IDLE_TIMEOUT TIMEOUT=43200                                                                             ; Set timeout to 12 hours
         SET_STEPPER_ENABLE STEPPER=extruder enable=0                                                               ; Disable extruder stepper
+        M400                                                                                                       ; Ensure parking moves are complete before returning
+    {% else %}
+        RESPOND MSG="PAUSE: Print already paused"                                                                  ; Avoid re-running the pause sequence twice
     {% endif %}
 
 
@@ -463,14 +469,15 @@ rename_existing: BASE_RESUME
 variable_zhop: 0
 variable_etemp: 0
 gcode:
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 1 %}
-        
-        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; check if z position is lost
-            {action_raise_error("ERROR: Z-axixs lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
+    {% if pause_state == 1 %}
+        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; Check if Z position is lost
+            {action_raise_error("ERROR: Z-axis lost its position (Idle-Timeout)! Resume not possible - print should be aborted.")}
         {% endif %}
-        
+
         SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
+        M400                                                                                                       ; Flush queued moves before restoring state
 
         # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE                                                                                     
         {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}                  ; If X/Y position is lost, but z is still OK
@@ -481,11 +488,17 @@ gcode:
         
         PRIME_NOZZLE HOTEND_TARGET_TEMP={etemp}                                                                    ; Prime nozzle with last used hotend temperature
 
-        M109 S{etemp}                                                                                              ; Wait for hotend to heat up
+        {% if etemp > 0 %}
+            M109 S{etemp|int}                                                                                      ; Wait for hotend to heat up
+        {% endif %}
 
         RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150                                                  ; Return to position after Z-hop (safely above the part)       
+        M400                                                                                                        ; Flush queued moves before final restore
         RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                        ; Restore position
-        BASE_RESUME                                                                                                ; Resume print                                                                         ; Resume print
+        M400                                                                                                        ; Ensure the final state restore is complete before resuming
+        BASE_RESUME                                                                                                ; Resume print
+    {% else %}
+        RESPOND MSG="RESUME: Print not paused"                                                                      ; Avoid re-running the resume sequence twice
     {% endif %}
 
 
@@ -494,23 +507,33 @@ gcode:
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT
 gcode:
-
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
-    {% if (printer.toolhead.position.z + 12) < max_z %}
-        {% set z_hop = 2  %}
+    {% set print_state = printer.print_stats.state|string|lower %}
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if print_state not in ["printing", "paused"] and pause_state == 0 %}
+        RESPOND MSG="CANCEL_PRINT: No active print to cancel"                                                       ; Avoid running the cancel sequence for a non-active job
+        BASE_CANCEL_PRINT
     {% else %}
-        {% set z_hop = 0 %}
+        {% if (printer.toolhead.position.z + 2) < max_z %}
+            {% set z_hop = 2  %}
+        {% else %}
+            {% set z_hop = 0 %}
+        {% endif %}
+
+        M400                                                                                                        ; Flush queued moves before cancel cleanup
+        G91                                                                                                         ; Relative positioning
+        G1 Z{z_hop} F600                                                                                            ; Do a tiny z-hop
+        G90                                                                                                         ; Absolute positioning
+
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
+        M400                                                                                                        ; Wait for the parking move to finish
+        CLEAR_PAUSE                                                                                                 ; Clear pause state before shutdown
+
+        PRINT_END
+        M400                                                                                                        ; Ensure shutdown moves are complete before canceling
+        BASE_CANCEL_PRINT
     {% endif %}
-
-    G91                                                                                                            ; Relative positioning
-    G1 Z{z_hop} F600                                                                                               ; Do a tiny z-hop
-    G90                                                                                                            ; Absolute positioning
-
-    G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
-    CLEAR_PAUSE
-
-    PRINT_END
-    BASE_CANCEL_PRINT
 
 
 [gcode_macro _Z_CLEARANCE]

--- a/config_section/X-Max3/macros.cfg
+++ b/config_section/X-Max3/macros.cfg
@@ -241,13 +241,16 @@ gcode:
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
 gcode:
-    {% set z_hop = params.Z|default(30)|int %}                                                                     ; Z hop amount
-    
-    {% if printer['pause_resume'].is_paused|int == 0 %}     
+    {% set z_hop = params.Z|default(30)|float %}                                                                   ; Z hop amount
+    {% set z_hop = [z_hop, 0.0]|max %}                                                                             ; Prevent negative Z hop input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if pause_state == 0 %}
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}                                                ; Set Z hop variable for reference in resume macro
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}                          ; Set hotend temperature variable for reference in resume macro
         SAVE_GCODE_STATE NAME=PAUSE                                                                                ; Save current position for resume
         BASE_PAUSE                                                                                                 ; Pause print
+        M400                                                                                                       ; Flush queued moves before parking
         {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}                         ; Check that Z hop doesn't exceed Z max
             G91                                                                                                    ; Use Relative positioning
             G1 Z{z_hop} F600                                                                                       ; Raise Z up by Z hop amount
@@ -256,11 +259,14 @@ gcode:
         {% endif %}
         SAVE_GCODE_STATE NAME=PAUSEPARK2
         G90                                                                                                        ; Absolute positioning
-        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead  at rear center
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead at rear center
         SAVE_GCODE_STATE NAME=PAUSEPARK                                                                            ; Save parked position in case toolhead is moved during the pause (otherwise the return zhop can error)
         M104 S0                                                                                                    ; Turn off hotend
         SET_IDLE_TIMEOUT TIMEOUT=43200                                                                             ; Set timeout to 12 hours
         SET_STEPPER_ENABLE STEPPER=extruder enable=0                                                               ; Disable extruder stepper
+        M400                                                                                                       ; Ensure parking moves are complete before returning
+    {% else %}
+        RESPOND MSG="PAUSE: Print already paused"                                                                  ; Avoid re-running the pause sequence twice
     {% endif %}
 
 
@@ -269,14 +275,17 @@ rename_existing: BASE_RESUME
 variable_zhop: 0
 variable_etemp: 0
 gcode:
-    {% set extrusion_length = params.E|default(2.5)|int %}                                                                        ; Hotend prime amount (in mm)
+    {% set extrusion_length = params.E|default(2.5)|float %}                                                       ; Hotend prime amount (in mm)
+    {% set extrusion_length = [extrusion_length, 0.0]|max %}                                                       ; Prevent negative prime input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 1 %}
-        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; check if z position is lost
-            {action_raise_error("ERROR: Z-axixs lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
+    {% if pause_state == 1 %}
+        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; Check if Z position is lost
+            {action_raise_error("ERROR: Z-axis lost its position (Idle-Timeout)! Resume not possible - print should be aborted.")}
         {% endif %}
-        
+
         SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
+        M400                                                                                                       ; Flush queued moves before restoring state
 
         # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE                                                                                     
         {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}                  ; If X/Y position is lost, but z is still OK
@@ -285,43 +294,57 @@ gcode:
             G90                                                                                                    ; Absolute positioning
         {% endif %}
 
-
         {% if etemp > 0 %}
             M109 S{etemp|int}                                                                                      ; Wait for hotend to heat up
         {% endif %}
         RESTORE_GCODE_STATE NAME=PAUSEPARK MOVE=1 MOVE_SPEED=150                                                   ; Restore back to parked position in case toolhead was moved during pause (otherwise the return zhop can error)  
+        M400                                                                                                        ; Wait for the restore move to finish before continuing
         G91                                                                                                        ; Relative positioning
         M83                                                                                                        ; Relative extruder positioning
-        {% if printer[printer.toolhead.extruder].temperature >= printer.configfile.settings.extruder.min_extrude_temp %}
-            G1  E{extrusion_length} F900                                                                                          ; Prime nozzle
-        {% endif %}  
-        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150                           
+        {% if printer[printer.toolhead.extruder].temperature >= printer.configfile.settings.extruder.min_extrude_temp and extrusion_length > 0 %}
+            G1 E{extrusion_length} F900                                                                             ; Prime nozzle
+        {% endif %}
+        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150
+        M400                                                                                                        ; Flush queued moves before final restore
         RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                        ; Restore position
+        M400                                                                                                        ; Ensure the final state restore is complete before resuming
         BASE_RESUME                                                                                                ; Resume print
         G90                                                                                                        ; Absolute positioning
+    {% else %}
+        RESPOND MSG="RESUME: Print not paused"                                                                      ; Avoid re-running the resume sequence twice
     {% endif %}
 
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT
 gcode:
-
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
-    {% if (printer.toolhead.position.z + 12) < max_z %}
-        {% set z_hop = 2  %}
+    {% set print_state = printer.print_stats.state|string|lower %}
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if print_state not in ["printing", "paused"] and pause_state == 0 %}
+        RESPOND MSG="CANCEL_PRINT: No active print to cancel"                                                       ; Avoid running the cancel sequence for a non-active job
+        BASE_CANCEL_PRINT
     {% else %}
-        {% set z_hop = 0 %}
+        {% if (printer.toolhead.position.z + 2) < max_z %}
+            {% set z_hop = 2  %}
+        {% else %}
+            {% set z_hop = 0 %}
+        {% endif %}
+
+        M400                                                                                                        ; Flush queued moves before cancel cleanup
+        G91                                                                                                         ; Relative positioning
+        G1 Z{z_hop} F600                                                                                            ; Do a tiny z-hop
+        G90                                                                                                         ; Absolute positioning
+
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
+        M400                                                                                                        ; Wait for the parking move to finish
+        CLEAR_PAUSE                                                                                                 ; Clear pause state before shutdown
+
+        PRINT_END
+        M400                                                                                                        ; Ensure shutdown moves are complete before canceling
+        BASE_CANCEL_PRINT
     {% endif %}
-
-    G91                                                                                                            ; Relative positioning
-    G1 Z{z_hop} F600                                                                                               ; Do a tiny z-hop
-    G90                                                                                                            ; Absolute positioning
-
-    G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
-    CLEAR_PAUSE
-
-    PRINT_END
-    BASE_CANCEL_PRINT
 
 
 [gcode_macro _Z_CLEARANCE]

--- a/config_section/X-Plus3/macros.cfg
+++ b/config_section/X-Plus3/macros.cfg
@@ -240,13 +240,16 @@ gcode:
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
 gcode:
-    {% set z_hop = params.Z|default(30)|int %}                                                                     ; Z hop amount
+    {% set z_hop = params.Z|default(30)|float %}                                                                   ; Z hop amount
+    {% set z_hop = [z_hop, 0.0]|max %}                                                                             ; Prevent negative Z hop input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 0 %}     
+    {% if pause_state == 0 %}
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}                                                ; Set Z hop variable for reference in resume macro
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}                          ; Set hotend temperature variable for reference in resume macro
         SAVE_GCODE_STATE NAME=PAUSE                                                                                ; Save current position for resume
         BASE_PAUSE                                                                                                 ; Pause print
+        M400                                                                                                       ; Flush queued moves before parking
         {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}                         ; Check that Z hop doesn't exceed Z max
             G91                                                                                                    ; Use Relative positioning
             G1 Z{z_hop} F600                                                                                       ; Raise Z up by Z hop amount
@@ -255,11 +258,14 @@ gcode:
         {% endif %}
         SAVE_GCODE_STATE NAME=PAUSEPARK2
         G90                                                                                                        ; Absolute positioning
-        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead  at rear center
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead at rear center
         SAVE_GCODE_STATE NAME=PAUSEPARK                                                                            ; Save parked position in case toolhead is moved during the pause (otherwise the return zhop can error)
         M104 S0                                                                                                    ; Turn off hotend
         SET_IDLE_TIMEOUT TIMEOUT=43200                                                                             ; Set timeout to 12 hours
         SET_STEPPER_ENABLE STEPPER=extruder enable=0                                                               ; Disable extruder stepper
+        M400                                                                                                       ; Ensure parking moves are complete before returning
+    {% else %}
+        RESPOND MSG="PAUSE: Print already paused"                                                                  ; Avoid re-running the pause sequence twice
     {% endif %}
 
 
@@ -268,16 +274,19 @@ rename_existing: BASE_RESUME
 variable_zhop: 0
 variable_etemp: 0
 gcode:
-    {% set extrusion_length = params.E|default(2.5)|int %}                                                                        ; Hotend prime amount (in mm)
+    {% set extrusion_length = params.E|default(2.5)|float %}                                                       ; Hotend prime amount (in mm)
+    {% set extrusion_length = [extrusion_length, 0.0]|max %}                                                       ; Prevent negative prime input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 1 %}
-        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; check if z position is lost
-            {action_raise_error("ERROR: Z-axixs lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
+    {% if pause_state == 1 %}
+        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; Check if Z position is lost
+            {action_raise_error("ERROR: Z-axis lost its position (Idle-Timeout)! Resume not possible - print should be aborted.")}
         {% endif %}
-        
-        SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
 
-        # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE                                                                                     
+        SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
+        M400                                                                                                       ; Flush queued moves before restoring state
+
+        # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE
         {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}                  ; If X/Y position is lost, but z is still OK
             G91                                                                                                    ; Relative positioning
             G1 Z5 F600                                                                                             ; 5mm clearance for safe X/Y-Homing
@@ -285,41 +294,56 @@ gcode:
         {% endif %}
 
         {% if etemp > 0 %}
-            M109 S{etemp|int}                                                                                      ; Wait for hotend to heat up
+            M109 S{etemp|int}                                                                                       ; Wait for hotend to heat up
         {% endif %}
-        RESTORE_GCODE_STATE NAME=PAUSEPARK MOVE=1 MOVE_SPEED=150                                                   ; Restore back to parked position in case toolhead was moved during pause (otherwise the return zhop can error)  
-        G91                                                                                                        ; Relative positioning
-        M83                                                                                                        ; Relative extruder positioning
-        {% if printer[printer.toolhead.extruder].temperature >= printer.configfile.settings.extruder.min_extrude_temp %}
-            G1  E{extrusion_length} F900                                                                                          ; Prime nozzle
-        {% endif %}  
-        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150                           
-        RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                        ; Restore position
-        BASE_RESUME                                                                                                ; Resume print
-        G90                                                                                                        ; Absolute positioning
+        RESTORE_GCODE_STATE NAME=PAUSEPARK MOVE=1 MOVE_SPEED=150                                                    ; Restore back to parked position in case toolhead was moved during pause (otherwise the return zhop can error)
+        M400                                                                                                        ; Wait for the restore move to finish before continuing
+        G91                                                                                                         ; Relative positioning
+        M83                                                                                                         ; Relative extruder positioning
+        {% if printer[printer.toolhead.extruder].temperature >= printer.configfile.settings.extruder.min_extrude_temp and extrusion_length > 0 %}
+            G1 E{extrusion_length} F900                                                                             ; Prime nozzle
+        {% endif %}
+        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150
+        M400                                                                                                        ; Flush queued moves before final restore
+        RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                         ; Restore position
+        M400                                                                                                        ; Ensure the final state restore is complete before resuming
+        BASE_RESUME                                                                                                 ; Resume print
+        G90                                                                                                         ; Absolute positioning
+    {% else %}
+        RESPOND MSG="RESUME: Print not paused"                                                                      ; Avoid re-running the resume sequence twice
     {% endif %}
 
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT
 gcode:
-
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
-    {% if (printer.toolhead.position.z + 12) < max_z %}
-        {% set z_hop = 2  %}
+    {% set print_state = printer.print_stats.state|string|lower %}
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if print_state not in ["printing", "paused"] and pause_state == 0 %}
+        RESPOND MSG="CANCEL_PRINT: No active print to cancel"                                                       ; Avoid running the cancel sequence for a non-active job
+        BASE_CANCEL_PRINT
     {% else %}
-        {% set z_hop = 0 %}
+        {% if (printer.toolhead.position.z + 2) < max_z %}
+            {% set z_hop = 2  %}
+        {% else %}
+            {% set z_hop = 0 %}
+        {% endif %}
+
+        M400                                                                                                        ; Flush queued moves before cancel cleanup
+        G91                                                                                                         ; Relative positioning
+        G1 Z{z_hop} F600                                                                                            ; Do a tiny z-hop
+        G90                                                                                                         ; Absolute positioning
+
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
+        M400                                                                                                        ; Wait for the parking move to finish
+        CLEAR_PAUSE                                                                                                 ; Clear pause state before shutdown
+
+        PRINT_END
+        M400                                                                                                        ; Ensure shutdown moves are complete before canceling
+        BASE_CANCEL_PRINT
     {% endif %}
-
-    G91                                                                                                            ; Relative positioning
-    G1 Z{z_hop} F600                                                                                               ; Do a tiny z-hop
-    G90                                                                                                            ; Absolute positioning
-
-    G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
-    CLEAR_PAUSE
-
-    PRINT_END
-    BASE_CANCEL_PRINT
 
 
 [gcode_macro _Z_CLEARANCE]

--- a/config_section/X-Smart3/macros.cfg
+++ b/config_section/X-Smart3/macros.cfg
@@ -238,13 +238,16 @@ gcode:
 [gcode_macro PAUSE]
 rename_existing: BASE_PAUSE
 gcode:
-    {% set z_hop = params.Z|default(30)|int %}                                                                     ; Z hop amount
+    {% set z_hop = params.Z|default(30)|float %}                                                                   ; Z hop amount
+    {% set z_hop = [z_hop, 0.0]|max %}                                                                             ; Prevent negative Z hop input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 0 %}     
+    {% if pause_state == 0 %}
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=zhop VALUE={z_hop}                                                ; Set Z hop variable for reference in resume macro
         SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=etemp VALUE={printer['extruder'].target}                          ; Set hotend temperature variable for reference in resume macro
         SAVE_GCODE_STATE NAME=PAUSE                                                                                ; Save current position for resume
         BASE_PAUSE                                                                                                 ; Pause print
+        M400                                                                                                       ; Flush queued moves before parking
         {% if (printer.gcode_move.position.z + z_hop) < printer.toolhead.axis_maximum.z %}                         ; Check that Z hop doesn't exceed Z max
             G91                                                                                                    ; Use Relative positioning
             G1 Z{z_hop} F600                                                                                       ; Raise Z up by Z hop amount
@@ -253,11 +256,14 @@ gcode:
         {% endif %}
         SAVE_GCODE_STATE NAME=PAUSEPARK2
         G90                                                                                                        ; Absolute positioning
-        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead  at rear center
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F6000                        ; Park toolhead at rear center
         SAVE_GCODE_STATE NAME=PAUSEPARK                                                                            ; Save parked position in case toolhead is moved during the pause (otherwise the return zhop can error)
         M104 S0                                                                                                    ; Turn off hotend
         SET_IDLE_TIMEOUT TIMEOUT=43200                                                                             ; Set timeout to 12 hours
         SET_STEPPER_ENABLE STEPPER=extruder enable=0                                                               ; Disable extruder stepper
+        M400                                                                                                       ; Ensure parking moves are complete before returning
+    {% else %}
+        RESPOND MSG="PAUSE: Print already paused"                                                                  ; Avoid re-running the pause sequence twice
     {% endif %}
 
 
@@ -266,15 +272,17 @@ rename_existing: BASE_RESUME
 variable_zhop: 0
 variable_etemp: 0
 gcode:
-    {% set extrusion_length = params.E|default(2.5)|int %}                                                                        ; Hotend prime amount (in mm)
+    {% set extrusion_length = params.E|default(2.5)|float %}                                                       ; Hotend prime amount (in mm)
+    {% set extrusion_length = [extrusion_length, 0.0]|max %}                                                       ; Prevent negative prime input
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
 
-    {% if printer['pause_resume'].is_paused|int == 1 %}
-        
-        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; check if z position is lost
-            {action_raise_error("ERROR: Z-axixs lost its position (Idle-Timeout)! Resume not possible - Print should be aborted.")}
+    {% if pause_state == 1 %}
+        {% if "z" not in printer.toolhead.homed_axes %}                                                            ; Check if Z position is lost
+            {action_raise_error("ERROR: Z-axis lost its position (Idle-Timeout)! Resume not possible - print should be aborted.")}
         {% endif %}
-        
+
         SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}                                ; Set idle timeout back to configured value
+        M400                                                                                                       ; Flush queued moves before restoring state
 
         # If X/Y position lost: Give Z-clearance for homing X/Y that will be done by PRIME_NOZZLE                                                                                     
         {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes %}                  ; If X/Y position is lost, but z is still OK
@@ -283,43 +291,57 @@ gcode:
             G90                                                                                                    ; Absolute positioning
         {% endif %}
 
-
         {% if etemp > 0 %}
             M109 S{etemp|int}                                                                                      ; Wait for hotend to heat up
         {% endif %}
         RESTORE_GCODE_STATE NAME=PAUSEPARK MOVE=1 MOVE_SPEED=150                                                   ; Restore back to parked position in case toolhead was moved during pause (otherwise the return zhop can error)  
+        M400                                                                                                        ; Wait for the restore move to finish before continuing
         G91                                                                                                        ; Relative positioning
         M83                                                                                                        ; Relative extruder positioning
-        {% if printer[printer.toolhead.extruder].temperature >= printer.configfile.settings.extruder.min_extrude_temp %}
-            G1  E{extrusion_length} F900                                                                                          ; Prime nozzle
-        {% endif %}  
-        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150                           
+        {% if printer[printer.toolhead.extruder].temperature >= printer.configfile.settings.extruder.min_extrude_temp and extrusion_length > 0 %}
+            G1 E{extrusion_length} F900                                                                             ; Prime nozzle
+        {% endif %}
+        RESTORE_GCODE_STATE NAME=PAUSEPARK2 MOVE=1 MOVE_SPEED=150
+        M400                                                                                                        ; Flush queued moves before final restore
         RESTORE_GCODE_STATE NAME=PAUSE MOVE=1 MOVE_SPEED=10                                                        ; Restore position
+        M400                                                                                                        ; Ensure the final state restore is complete before resuming
         BASE_RESUME                                                                                                ; Resume print
         G90                                                                                                        ; Absolute positioning
+    {% else %}
+        RESPOND MSG="RESUME: Print not paused"                                                                      ; Avoid re-running the resume sequence twice
     {% endif %}
 
 
 [gcode_macro CANCEL_PRINT]
 rename_existing: BASE_CANCEL_PRINT
 gcode:
-
     {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
-    {% if (printer.toolhead.position.z + 12) < max_z %}
-        {% set z_hop = 2  %}
+    {% set print_state = printer.print_stats.state|string|lower %}
+    {% set pause_state = printer['pause_resume'].is_paused|int %}
+
+    {% if print_state not in ["printing", "paused"] and pause_state == 0 %}
+        RESPOND MSG="CANCEL_PRINT: No active print to cancel"                                                       ; Avoid running the cancel sequence for a non-active job
+        BASE_CANCEL_PRINT
     {% else %}
-        {% set z_hop = 0 %}
+        {% if (printer.toolhead.position.z + 2) < max_z %}
+            {% set z_hop = 2  %}
+        {% else %}
+            {% set z_hop = 0 %}
+        {% endif %}
+
+        M400                                                                                                        ; Flush queued moves before cancel cleanup
+        G91                                                                                                         ; Relative positioning
+        G1 Z{z_hop} F600                                                                                            ; Do a tiny z-hop
+        G90                                                                                                         ; Absolute positioning
+
+        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
+        M400                                                                                                        ; Wait for the parking move to finish
+        CLEAR_PAUSE                                                                                                 ; Clear pause state before shutdown
+
+        PRINT_END
+        M400                                                                                                        ; Ensure shutdown moves are complete before canceling
+        BASE_CANCEL_PRINT
     {% endif %}
-
-    G91                                                                                                            ; Relative positioning
-    G1 Z{z_hop} F600                                                                                               ; Do a tiny z-hop
-    G90                                                                                                            ; Absolute positioning
-
-    G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_maximum.y-40} F12000
-    CLEAR_PAUSE
-
-    PRINT_END
-    BASE_CANCEL_PRINT
 
 
 [gcode_macro _Z_CLEARANCE]


### PR DESCRIPTION
**Summery**
This PR standardizes print-interruption safety behaviour and macro readability across all supported machine profiles by aligning PAUSE, RESUME, and CANCEL_PRINT logic and comment blocks.

### What Changed

- [x] - Added/aligned safety safeguards in PAUSE, RESUME, and CANCEL_PRINT:
- [x] - Prevent negative Z-hop and negative prime inputs.
- [x] - Guard against duplicate PAUSE/RESUME calls.
- [x] - Guard CANCEL_PRINT when there is no active print.
- [x] - Added synchronization points to ensure motion/state commands complete in safe order.
- [x] - Preserved model-specific behaviour (for example, bucket/park movement differences where intended).
- [x] - Unified wording and formatting for the same safety steps.
- [x] - Removed inconsistent or duplicated trailing comments.
- [x] - Kept comments behaviour-focused and easier to compare profile-to-profile.
- [x] - Normalized comment blocks across all machine macro implementations:

### Why This Is Important
Improves print safety:
- Reduces chances of unsafe moves and state corruption during pause/resume/cancel edge cases.
- Prevents accidental repeated macro execution from causing unintended behaviour.

Improves reliability and consistency:
- All machines now follow the same defensive patterns for interruption flow being predictable for users switching between printer models.

Improves maintainability:
- Consistent comment blocks and structure make reviews, debugging, and future edits faster.
- Easier to propagate future macro fixes to all profiles with lower risk.

### Behavioral Impact
Normal printing flow is unchanged.
Changes primarily affect edge cases and interruption handling (pause/resume/cancel scenarios).