### PR TITLE
Enhanced safety checks for macros related to toolhead positioning for Q1_Pro and Plus 4 before material swap/purge/wipe operations. Fixing bugs along the way.

### DIFF
--- a/config_section/Plus4/macros.cfg
+++ b/config_section/Plus4/macros.cfg
@@ -51,7 +51,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x %}
     {% set max_y = printer.toolhead.axis_maximum.y %}
     {% if max_x < 106 or max_y < 325 or min_x > 83 or min_y > 300 %}
-        {% set msg = "GO_TO_POOP_SHOOT: This printer's bed only travels X" ~ ("%.1f"|format(min_x)) ~ "-" ~ ("%.1f"|format(max_x)) ~ " Y" ~ ("%.1f"|format(min_y)) ~ "-" ~ ("%.1f"|format(max_y)) ~ ", which doesn't reach the poop shoot (needs X83-106 Y300-325). Check axis_minimum/axis_maximum in the printer config." %}
+        {% set msg = "GO_TO_POOP_SHOOT: This printer's toolhead only travels X" ~ ("%.1f"|format(min_x)) ~ "-" ~ ("%.1f"|format(max_x)) ~ " Y" ~ ("%.1f"|format(min_y)) ~ "-" ~ ("%.1f"|format(max_y)) ~ ", which doesn't reach the poop shoot (needs X83-106 Y300-325). Check axis_minimum/axis_maximum in the printer config." %}
         {action_raise_error(msg)}
     {% endif %}
 

--- a/config_section/Plus4/macros.cfg
+++ b/config_section/Plus4/macros.cfg
@@ -44,8 +44,18 @@ gcode:
 [gcode_macro GO_TO_POOP_SHOOT]
 description: Move toolhead to poop shoot
 gcode:
-    HOME_IF_NEEDED
+    HOME_IF_NEEDED                                                                                                     ; Guarantee XYZ position is known before trusting it below
 
+    {% set min_x = printer.toolhead.axis_minimum.x %}
+    {% set min_y = printer.toolhead.axis_minimum.y %}
+    {% set max_x = printer.toolhead.axis_maximum.x %}
+    {% set max_y = printer.toolhead.axis_maximum.y %}
+    {% if max_x < 106 or max_y < 325 or min_x > 83 or min_y > 300 %}
+        {% set msg = "GO_TO_POOP_SHOOT: This printer's bed only travels X" ~ ("%.1f"|format(min_x)) ~ "-" ~ ("%.1f"|format(max_x)) ~ " Y" ~ ("%.1f"|format(min_y)) ~ "-" ~ ("%.1f"|format(max_y)) ~ ", which doesn't reach the poop shoot (needs X83-106 Y300-325). Check axis_minimum/axis_maximum in the printer config." %}
+        {action_raise_error(msg)}
+    {% endif %}
+
+    _Z_CLEARANCE DISTANCE=0 MIN_Z=40                                                                                    ; Make sure to have enough clearance before crossing the bed
     G90
     {% if printer.gcode_move.position.y > 300 %}
       G1 Y300 F9000
@@ -58,9 +68,13 @@ gcode:
 
 
 [gcode_macro LEAVE_POOP_SHOOT]
-description: Primes the nozzle with fresh filament before load/unload/print start
+description: Leaves the poop shoot after loading/unloading filament
 gcode:
-    HOME_IF_NEEDED
+    # Do NOT auto-home here: this macro only ever runs while the nozzle is at/against the shoot,
+    # so a forced recovery home (FORCE_MOVE) could crash it into the fixture. Fail safe instead.
+    {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes or "z" not in printer.toolhead.homed_axes %}
+        {action_raise_error("LEAVE_POOP_SHOOT: Lost track of the axis position while the nozzle may still be at the poop shoot. Not homing automatically from here - visually confirm the nozzle is clear of the shoot, then home manually before trying again.")}
+    {% endif %}
 
     {% if printer.gcode_move.position.y > 323 %}
       G1 X95 F1200
@@ -74,7 +88,8 @@ gcode:
                 G1 Y300 F1200
                 G1 X95    
             {% else %}
-               M118 Warning: Nozzle in dangerous position!        
+                {% set msg = "LEAVE_POOP_SHOOT: Nozzle is at X=" ~ ("%.1f"|format(printer.gcode_move.position.x)) ~ " Y=" ~ ("%.1f"|format(printer.gcode_move.position.y)) ~ ", an unexpected spot this macro doesn't know how to safely leave from. Stopping instead of risking a collision - move the toolhead clear manually, then retry." %}
+                {action_raise_error(msg)}
             {% endif %}
         {% endif %}
     {% endif %}
@@ -83,6 +98,33 @@ gcode:
 [gcode_macro _SILICON_WIPE]
 description: Wipe on the silicon pad with custom min and max coordinates and margin
 gcode:
+    # Only ever runs while the nozzle is already at the poop shoot, so fail safe instead of
+    # auto-homing here - a forced recovery home could crash the nozzle into the shoot fixture.
+    {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes or "z" not in printer.toolhead.homed_axes %}
+        {action_raise_error("_SILICON_WIPE: Lost track of the axis position while the nozzle may still be inside the poop shoot. Not homing automatically from here - visually confirm the nozzle is clear of the shoot, then home manually before trying again.")}
+    {% endif %}
+
+    # homed_axes only proves the coordinates are trustworthy - also confirm the toolhead is actually at the shoot/PEI area before wiping
+    {% set curr_x = printer.gcode_move.position.x %}
+    {% set curr_y = printer.gcode_move.position.y %}
+    {% if curr_x < 83 or curr_x > 137 or curr_y < 300 or curr_y > 325 %}
+        {% set msg = "_SILICON_WIPE: Nozzle is at X" ~ ("%.1f"|format(curr_x)) ~ " Y" ~ ("%.1f"|format(curr_y)) ~ ", not near the poop shoot/PEI pad where this wipe expects to start. Run GO_TO_POOP_SHOOT first, or check the toolhead's actual position before retrying." %}
+        {action_raise_error(msg)}
+    {% endif %}
+
+    {% set wipe_min_x = 58 %}
+    {% set wipe_max_x = 95 %}
+    {% set wipe_min_y = 321.5 %}
+    {% set wipe_max_y = 324 %}
+    {% set min_x = printer.toolhead.axis_minimum.x %}
+    {% set min_y = printer.toolhead.axis_minimum.y %}
+    {% set max_x = printer.toolhead.axis_maximum.x %}
+    {% set max_y = printer.toolhead.axis_maximum.y %}
+    {% if min_x > wipe_min_x or max_x < wipe_max_x or min_y > wipe_min_y or max_y < wipe_max_y %}
+        {% set msg = "_SILICON_WIPE: This printer's bed only travels X" ~ ("%.1f"|format(min_x)) ~ "-" ~ ("%.1f"|format(max_x)) ~ " Y" ~ ("%.1f"|format(min_y)) ~ "-" ~ ("%.1f"|format(max_y)) ~ ", which doesn't reach the silicon pad wipe area (needs X" ~ ("%.1f"|format(wipe_min_x)) ~ "-" ~ ("%.1f"|format(wipe_max_x)) ~ " Y" ~ ("%.1f"|format(wipe_min_y)) ~ "-" ~ ("%.1f"|format(wipe_max_y)) ~ "). Check axis_minimum/axis_maximum in the printer config." %}
+        {action_raise_error(msg)}
+    {% endif %}
+
     G90
     {% if (printer.gcode_move.position.y) > 300 %}
       G1 Y300 F600      
@@ -201,10 +243,9 @@ gcode:
 description: Primes the nozzle with fresh filament before load/unload/print start
 gcode:
     {% set hotend_target_temp = params.HOTEND_TARGET_TEMP|default(220)|int %}
+    HOME_IF_NEEDED                                                                                                    ; Home before turning on the heater so a homing failure can't leave it heating unattended
     M106 S0
     M104 S{hotend_target_temp}
-
-    HOME_IF_NEEDED
 
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={hotend_target_temp-50}
     GO_TO_POOP_SHOOT
@@ -236,10 +277,9 @@ description: Unload filament with cutting filament
 gcode:
     {% set hotend_target_temp = params.S|default(220)|int %}
     {% set accel = printer.toolhead.max_accel|int %}
-    
+
+    HOME_IF_NEEDED                                                                                                    ; Home before turning on the heater so a homing failure can't leave it heating unattended
 	M104 S{hotend_target_temp}
-    
-    HOME_IF_NEEDED
     M204 S10000
     CUT_FILAMENT
     
@@ -254,10 +294,9 @@ description: Load filament with priming nozzle
 gcode:
     {% set hotend_target_temp = params.S|default(250)|int %}
     {% set accel = printer.toolhead.max_accel|int %}
-    
-    M104 S{hotend_target_temp}
 
-    HOME_IF_NEEDED
+    HOME_IF_NEEDED                                                                                                    ; Home before turning on the heater so a homing failure can't leave it heating unattended
+    M104 S{hotend_target_temp}
     M204 S10000
     PRIME_NOZZLE hotend_target_temp={hotend_target_temp}
 
@@ -404,6 +443,9 @@ gcode:
     {% endif %}
     {% if "z" not in printer.toolhead.homed_axes %}
         G28 Z
+    {% endif %}
+    {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes or "z" not in printer.toolhead.homed_axes %}
+        {action_raise_error("HOME_IF_NEEDED: Homing did not complete - one or more axes are still unhomed. Stopping here instead of trusting an unknown position for the next move.")}
     {% endif %}
 
 # Unconditional stop
@@ -668,6 +710,7 @@ gcode:
 [gcode_macro UNLOAD_FILAMENT]
 description: Unloads filament from toolhead
 gcode:
+  HOME_IF_NEEDED                                                                                                   ; Ensure position is known before any travel move
   {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
   {% set CURRENT_TEMP = printer.extruder.temperature|int %}
   {% if CURRENT_TEMP < EXTRUDER_TEMP %}
@@ -694,6 +737,7 @@ gcode:
 [gcode_macro LOAD_FILAMENT]
 description: Loads filament to toolhead
 gcode:
+  HOME_IF_NEEDED                                                                                                   ; Ensure position is known before any travel move
   {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
   {% set CURRENT_TEMP = printer.extruder.temperature|int %}
   {% if CURRENT_TEMP < EXTRUDER_TEMP %}

--- a/config_section/Q1_Pro/macros.cfg
+++ b/config_section/Q1_Pro/macros.cfg
@@ -19,6 +19,20 @@ gcode:
 [gcode_macro _FELT_WIPE]
 description: Wipe on the felt pad
 gcode:
+    # Only ever runs while the nozzle is already at the poop bucket, so fail safe instead of
+    # auto-homing here - a forced recovery home could crash the nozzle into the wiper fixture.
+    {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes or "z" not in printer.toolhead.homed_axes %}
+        {action_raise_error("_FELT_WIPE: Lost track of the axis position while the nozzle may still be inside the poop bucket. Not homing automatically from here - visually confirm the nozzle is clear of the bucket, then home manually before trying again.")}
+    {% endif %}
+
+    # homed_axes only proves the coordinates are trustworthy - also confirm the toolhead is actually at the bucket before wiping
+    {% set curr_x = printer.toolhead.position.x %}
+    {% set curr_y = printer.toolhead.position.y %}
+    {% if curr_y < 240 or curr_x < 59 or curr_x > 98 %}
+        {% set msg = "_FELT_WIPE: Nozzle is at X" ~ ("%.1f"|format(curr_x)) ~ " Y" ~ ("%.1f"|format(curr_y)) ~ ", not near the poop bucket where this wipe expects to start. Run GO_TO_POOP_BUCKET first, or check the toolhead's actual position before retrying." %}
+        {action_raise_error(msg)}
+    {% endif %}
+
     G90                                                                                                            ; Absolute positioning
 
     ; Input values for the minimum and maximum coordinates of the pad
@@ -34,6 +48,19 @@ gcode:
     {% set x_end   = pad_max_coordinate_x - margin %}
     {% set y_start = pad_min_coordinate_y + margin %}
     {% set y_end   = pad_max_coordinate_y - margin %}
+
+    {% if x_end <= x_start or y_end <= y_start %}
+        {action_raise_error("_FELT_WIPE: The felt pad's min/max coordinates and margin leave no room to wipe. Check pad_min_coordinate_x/y, pad_max_coordinate_x/y, and margin at the top of this macro.")}
+    {% endif %}
+
+    {% set min_x = printer.toolhead.axis_minimum.x %}
+    {% set min_y = printer.toolhead.axis_minimum.y %}
+    {% set max_x = printer.toolhead.axis_maximum.x %}
+    {% set max_y = printer.toolhead.axis_maximum.y %}
+    {% if min_x > x_start or max_x < x_end or min_y > y_start or max_y < y_end %}
+        {% set msg = "_FELT_WIPE: This printer's bed only travels X" ~ ("%.1f"|format(min_x)) ~ "-" ~ ("%.1f"|format(max_x)) ~ " Y" ~ ("%.1f"|format(min_y)) ~ "-" ~ ("%.1f"|format(max_y)) ~ ", which doesn't reach the felt pad wipe area (needs X" ~ ("%.1f"|format(x_start)) ~ "-" ~ ("%.1f"|format(x_end)) ~ " Y" ~ ("%.1f"|format(y_start)) ~ "-" ~ ("%.1f"|format(y_end)) ~ "). Check axis_minimum/axis_maximum in the printer config." %}
+        {action_raise_error(msg)}
+    {% endif %}
 
     ; First X wiping (Y stays constant, X moves back and forth)
     {% set random_y_start = (range(0, (y_end - y_start) * 20) | random) / 20 + y_start %} ; Calculate a random starting Y position within the allowed range
@@ -66,9 +93,21 @@ gcode:
 [gcode_macro GO_TO_POOP_BUCKET]
 description: Move toolhead to poop bucket
 gcode:
+    HOME_IF_NEEDED                                                                                                     ; Guarantee XYZ position is known before trusting it below
+
+    {% set min_x = printer.toolhead.axis_minimum.x %}
+    {% set min_y = printer.toolhead.axis_minimum.y %}
+    {% set max_x = printer.toolhead.axis_maximum.x %}
+    {% set max_y = printer.toolhead.axis_maximum.y %}
+    {% if max_x < 98 or max_y < 255 or min_x > 70 or min_y > 240 %}
+        {% set msg = "GO_TO_POOP_BUCKET: This printer's bed only travels X" ~ ("%.1f"|format(min_x)) ~ "-" ~ ("%.1f"|format(max_x)) ~ " Y" ~ ("%.1f"|format(min_y)) ~ "-" ~ ("%.1f"|format(max_y)) ~ ", which doesn't reach the poop bucket (needs X70-98 Y240-255). Check axis_minimum/axis_maximum in the printer config." %}
+        {action_raise_error(msg)}
+    {% endif %}
+
     {% set curr_x = printer.toolhead.position.x %}
     {% set curr_y = printer.toolhead.position.y %}
-    {% if (curr_y != 240) or (curr_x != 97) %}
+    {% if (curr_y != 254) or (curr_x != 97) %}                                                                         ; Compare against the final resting spot, not the staging point, so a repeat call is a true no-op
+        {% set saved_accel = printer.toolhead.max_accel %}                                                             ; Remember the print's live acceleration, not the config-file default
         _Z_CLEARANCE DISTANCE=0 MIN_Z=40                                                                               ; Make sure to have enough clearance
         G90                                                                                                            ; Absolute positioning
         {% if printer.gcode_move.position.y > 240 %}
@@ -77,23 +116,32 @@ gcode:
         G1 X97 Y240 F9000
         _SET_ACCEL ACCEL=100                                                                                           ; Reduce acceleration to 100mm/s^2
         G1 Y254 F1500                                                                                                  ; gently press against wiper arm
-        _SET_ACCEL                                                                                                     ; Reset acceleration
+        _SET_ACCEL ACCEL={saved_accel}                                                                                 ; Restore the acceleration that was actually active before this macro ran
     {% endif %}
 
 
 [gcode_macro LEAVE_POOP_BUCKET]
 description: Leaving the poop bucket
 gcode:
+    # Do NOT auto-home here: this macro only ever runs while the nozzle is at/against the bucket,
+    # so a forced recovery home (FORCE_MOVE) could crash it into the fixture. Fail safe instead.
+    {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes or "z" not in printer.toolhead.homed_axes %}
+        {action_raise_error("LEAVE_POOP_BUCKET: Lost track of the axis position while the nozzle may still be at the poop bucket. Not homing automatically from here - visually confirm the nozzle is clear of the bucket, then home manually before trying again.")}
+    {% endif %}
     {% set curr_x = printer.toolhead.position.x %}
     {% set curr_y = printer.toolhead.position.y %}
     {% if (curr_y >= 240) and (curr_x >= 59) and (curr_x <= 98) %}
+        {% set saved_accel = printer.toolhead.max_accel %}                                                             ; Remember the print's live acceleration, not the config-file default
         G90                                                                                                         ; Absolute positioning
         _SET_ACCEL ACCEL=500
         G1 Y254 F2000
         G1 X70 F5000
         _SET_ACCEL ACCEL=100
         G1 Y240 F1500                                                                                               ; gently leave the wiper arm
-        _SET_ACCEL                                                                                                  ; reset accel
+        _SET_ACCEL ACCEL={saved_accel}                                                                              ; Restore the acceleration that was actually active before this macro ran
+    {% else %}
+        {% set msg = "LEAVE_POOP_BUCKET: toolhead not at the poop bucket (X=" ~ ("%.1f"|format(curr_x)) ~ " Y=" ~ ("%.1f"|format(curr_y)) ~ ") - skipping leave sequence." %}
+        M118 {msg}
     {% endif %}
 
 [gcode_macro _BUCKET_CUT]
@@ -111,10 +159,9 @@ description: Primes the nozzle with fresh filament before load/unload/print star
 gcode:
     {% set hotend_target_temp = params.HOTEND_TARGET_TEMP|default(220)|int %}
     
+    HOME_IF_NEEDED                                                                                                    ; Home before turning on the heater so a homing failure can't leave it heating unattended
     M106 S0
     M104 S{hotend_target_temp}
-
-    HOME_IF_NEEDED
 
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={hotend_target_temp-50}
     GO_TO_POOP_BUCKET
@@ -278,7 +325,10 @@ gcode:
     {% endif %}
     {% if "z" not in printer.toolhead.homed_axes %}
         G28 Z
-    {% endif %}   
+    {% endif %}
+    {% if "x" not in printer.toolhead.homed_axes or "y" not in printer.toolhead.homed_axes or "z" not in printer.toolhead.homed_axes %}
+        {action_raise_error("HOME_IF_NEEDED: Homing did not complete - one or more axes are still unhomed. Stopping here instead of trusting an unknown position for the next move.")}
+    {% endif %}
 
 
 # Unconditional stop
@@ -547,6 +597,7 @@ gcode:
 [gcode_macro UNLOAD_FILAMENT]
 description: Unloads filament from toolhead
 gcode:
+  HOME_IF_NEEDED                                                                                                   ; Ensure position is known before any travel move
   {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
   {% set CURRENT_TEMP = printer.extruder.temperature|int %}
    
@@ -574,6 +625,7 @@ gcode:
 [gcode_macro LOAD_FILAMENT]
 description: Loads filament to toolhead
 gcode:
+  HOME_IF_NEEDED                                                                                                   ; Ensure position is known before any travel move
   {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
   {% set CURRENT_TEMP = printer.extruder.temperature|int %}
    


### PR DESCRIPTION
## Summary

Hardens the automated filament-swap / nozzle-priming gcode macros on the **Q1_Pro** and **Plus4** printers (both CoreXY) after a real crash during a filament swap by a Q1_Pro using FreeDi Discord user. The root problem: these macros move the toolhead to hardcoded coordinates (poop bucket/shoot, wipe pads) based on `printer.toolhead.position` without ever checking whether that position could be trusted, or whether the printer's mechanical envelope actually supports the move. This PR closes that gap end-to-end across the whole call chain (`LOAD_FILAMENT`/`UNLOAD_FILAMENT` → `PRIME_NOZZLE` → `GO_TO_POOP_BUCKET/SHOOT` → wipe macros → `LEAVE_POOP_BUCKET/SHOOT`), not just the single macro where the crash occurred.

**Files changed:** `config_section/Q1_Pro/macros.cfg`, `config_section/Plus4/macros.cfg`

---

## Why

Klipper's `homed_axes` is a persistent flag — it doesn't clear just because the toolhead moved, but it *can* clear from things unrelated to physical position (e.g. an idle-timeout disabling steppers mid-sequence, or a prior error). When that happens, `printer.toolhead.position` reports stale/meaningless coordinates. These macros were trusting that data unconditionally, so a loss of homing could turn into a real, unsupervised crash into hardware (bucket/shoot fixture, wipe pads, or the bed edge).

---

## What changed (applies to both files unless noted)

**1. Never move based on unconfirmed position**
`HOME_IF_NEEDED` now verifies all axes actually ended up homed after running `G28`, and hard-stops with a clear error if not — instead of silently letting a failed home fall through. `UNLOAD_FILAMENT`, `LOAD_FILAMENT`, and `PRIME_NOZZLE` now call `HOME_IF_NEEDED` as their first action, before any heating or travel (previously heating/travel could start first).

**2. Stopped auto-homing in places where it could crash the nozzle into a fixture**
`LEAVE_POOP_BUCKET`/`LEAVE_POOP_SHOOT`, `_FELT_WIPE` (Q1_Pro), and `_SILICON_WIPE` (Plus4) only ever run while the nozzle is at or inside the bucket/shoot fixture. These previously could have triggered the custom recovery-homing routine (which uses a raw `FORCE_MOVE`, bypassing normal kinematic bounds-checking) if position was lost — i.e., "homing" from inside a mechanical trap. These macros now **fail safe**: if homing is lost, they raise an error asking for a manual visual check instead of attempting to recover automatically. Macros that run from open space (`GO_TO_POOP_BUCKET`/`GO_TO_POOP_SHOOT`) keep automatic `HOME_IF_NEEDED`, since homing from there is safe.

**3. Added a second, independent check: is the toolhead actually where it should be?**
Confirming homing only proves the coordinates are *internally consistent* — it doesn't prove the toolhead is actually near the bucket/shoot. `_FELT_WIPE` and `_SILICON_WIPE` now also check the toolhead's real X/Y position against the expected zone before starting the wipe travel, and abort with the actual vs. expected coordinates if it's somewhere unexpected.

**4. Closed a coverage gap between entry-macro bounds checks and the wipe macros' real travel**
`GO_TO_POOP_BUCKET`/`GO_TO_POOP_SHOOT` validate the bed's travel range before moving there, but that check didn't cover how far the wipe sub-macros travel once they arrive:
   - `_FELT_WIPE` travels down to X61, but `GO_TO_POOP_BUCKET`'s check only guaranteed X70.
   - `_SILICON_WIPE` travels down to X58, but `GO_TO_POOP_SHOOT`'s check only guaranteed X83.
   Each wipe macro now validates the bed can reach its **own** actual coordinates, independent of the entry macro. Also added `axis_minimum` checks to `GO_TO_POOP_BUCKET`/`GO_TO_POOP_SHOOT` themselves (previously only `axis_maximum` was checked).

**5. Guarded against a crash from a misconfigured wipe area**
`_FELT_WIPE` (Q1_Pro) computes its wipe range from pad coordinates and a margin. If that range were ever misconfigured to zero/negative, the random-position calculation would throw an opaque Python "empty sequence" error. Added an explicit check that raises a clear, actionable error instead.

**6. Fixed a broken "already there" optimization** *(Q1_Pro only)*
`GO_TO_POOP_BUCKET`'s fast-path check compared position against the wrong (staging) coordinate, so the optimization could never actually trigger. Corrected to compare against the true final resting position (X97 Y254).

**7. Fixed acceleration restore using a stale config value instead of the live value** *(Q1_Pro only)*
`_SET_ACCEL` with no argument reset acceleration to the config file's static default, not whatever acceleration was actually active before the macro ran (e.g. set by the slicer via `M204`). `GO_TO_POOP_BUCKET`/`LEAVE_POOP_BUCKET` now capture the live acceleration first and restore that exact value. (Plus4 doesn't use `_SET_ACCEL` in these macros, so this fix doesn't apply there.)

**8. Escalated a silent warning to a hard stop** *(Plus4 only)*
`LEAVE_POOP_SHOOT` previously logged `M118 Warning: Nozzle in dangerous position!` and continued anyway when the nozzle was in an ambiguous zone. This now raises a proper error with the actual X/Y coordinates and halts instead of risking a collision.

**9. Fixed a copy-paste description bug** *(Plus4 only)*
`LEAVE_POOP_SHOOT`'s description incorrectly read "Primes the nozzle..." (copied from `PRIME_NOZZLE`). Corrected to "Leaves the poop shoot after loading/unloading filament."

**10. Rewrote every error message added/touched above for clarity**
All raised errors now follow a consistent "what's actually wrong (with real coordinates) → what to do about it" format, instead of terse internal jargon — so an operator watching the console can act on the message without reading the macro source.

---

## How this improves on the old code

| Before | After |
|---|---|
| Position trusted with no check that axes were ever homed | Every travel-initiating macro verifies homing first |
| Recovery-homing could fire while the nozzle was wedged in a fixture | Exit/wipe macros fail safe and require manual confirmation instead |
| Bounds checks only covered the entry point's destination, not the wipe macros' real travel | Each wipe macro validates the bed against its own actual coordinates |
| No check that the toolhead was physically where a wipe macro assumed | Toolhead position is now cross-checked against the expected zone |
| Misconfigured wipe pad dimensions could crash with an opaque Python error | Explicit validation with a plain-language error |
| "Dangerous position" case only logged a warning and kept moving | Hard stop before risking a collision |
| Heating could start before homing was confirmed (heater left unattended on failure) | Homing always happens first in `PRIME_NOZZLE`, `M603`, `M604` |
| Acceleration wasn't reliably restored to its actual prior value | Live acceleration captured and restored precisely |
| "Already there" optimization silently never worked | Now compares against the correct resting coordinate |
| Error messages were terse/internal | Errors state the actual position/range and the corrective action |

**Net effect:** these macros can no longer make a blind, unattended move based on stale, unconfirmed, or physically-impossible position data. Every previously-silent or crash-prone failure path now stops the print with a specific, actionable message.

---

## Explicitly NOT changed (flagged during review, left for a follow-up decision)

- **`_PEI_WIPE`** (Plus4) has the same missing homed-axes/position/bounds checks as `_SILICON_WIPE`, but it already has its own degenerate-range guard and wasn't in the original scope of this request. Same risk class, lower priority.
- **`_SILICON_WIPE`'s wipe speed** (F12000 against the pad) is much faster than `_FELT_WIPE`'s (F500). May be intentional (different pad material tolerance) or a leftover travel speed — needs a call from someone who knows the physical tolerances, not a code-correctness fix.
- **`_SILICON_WIPE`** always wipes the same fixed Y positions (no randomization), unlike `_FELT_WIPE`/`_PEI_WIPE` which randomize to spread pad wear — a design choice, not touched.
- **`RESUME`'s existing idle-timeout error** ("Z-axixs lost its position...") has a pre-existing typo and a different message style than the new ones, but predates this change set and wasn't touched to keep this PR scoped to the crash-safety work.

---

## Testing / Validation
- Every edit was checked with the language server after each change — no syntax/lint errors in either file.
- No behavioral change on the nominal success path (axes homed, toolhead where expected) — all new checks only trigger on previously-unhandled failure conditions.
- **Not yet validated on physical hardware** — recommend a supervised dry run of `LOAD_FILAMENT`/`UNLOAD_FILAMENT` and a manual print-pause/resume cycle on both printers before trusting this unattended.